### PR TITLE
client side content caching

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,27 +1,103 @@
-// kwento/frontend/src/App.js
-
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import ThemeInput from "./components/ThemeInput";
 import BookModal from "./components/BookModal";
 import BookList from "./components/BookList";
 import { buildApiUrl } from "./config";
+import {
+  cacheShelfCover,
+  enforceCacheBudget,
+  getCachedFullBook,
+  getCachedShelfCover,
+  hasCachedShelfCover,
+  loadShelfMetadataSync,
+  saveFullBookPackage,
+  saveShelfMetadata,
+} from "./cache/libraryCache";
 
-const LIBRARY_CACHE_KEY = "kwento_library_books_v1";
+const COVER_DOWNLOAD_CONCURRENCY = 3;
+const INITIAL_VISIBLE_BOOK_COUNT = 6;
+
+const releaseObjectUrls = (urls = []) => {
+  if (typeof URL?.revokeObjectURL !== "function") {
+    return;
+  }
+
+  urls.forEach((url) => {
+    if (typeof url === "string" && url.startsWith("blob:")) {
+      URL.revokeObjectURL(url);
+    }
+  });
+};
 
 const App = () => {
   const [theme, setTheme] = useState("");
   const [book, setBook] = useState(null);
   const [loading, setLoading] = useState(false);
   const [, setExistingBookLoading] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false); // Controls BookModal visibility
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [libraryBooks, setLibraryBooks] = useState([]);
   const [libraryLoading, setLibraryLoading] = useState(false);
   const [libraryError, setLibraryError] = useState(false);
-  const [libraryHydrated, setLibraryHydrated] = useState(false);
+  const [visibleBookIds, setVisibleBookIds] = useState([]);
+  const [coverStateByBookId, setCoverStateByBookId] = useState({});
   const libraryFetchPromiseRef = useRef(null);
+  const cachedCoverUrlsRef = useRef({});
+  const cachedBookObjectUrlsRef = useRef([]);
+  const coverStateByBookIdRef = useRef({});
+  const coverQueueRef = useRef([]);
+  const queuedCoverBookIdsRef = useRef(new Set());
+  const pendingCoverBookIdsRef = useRef(new Set());
+
+  const updateCoverState = ({ bookId, status, sourceUrl }) => {
+    setCoverStateByBookId((currentState) => {
+      const previousState = currentState[bookId] ?? {};
+      const previousUrl = previousState.url;
+
+      if (previousUrl && previousUrl !== sourceUrl && previousUrl.startsWith("blob:")) {
+        URL.revokeObjectURL(previousUrl);
+      }
+
+      cachedCoverUrlsRef.current[bookId] = sourceUrl ?? null;
+
+      const nextState = {
+        ...currentState,
+        [bookId]: {
+          status,
+          url: sourceUrl ?? null,
+        },
+      };
+
+      coverStateByBookIdRef.current = nextState;
+      return nextState;
+    });
+  };
+
+  const markCoverStatus = (bookId, status) => {
+    setCoverStateByBookId((currentState) => {
+      const nextState = {
+        ...currentState,
+        [bookId]: {
+          ...(currentState[bookId] ?? {}),
+          status,
+        },
+      };
+
+      coverStateByBookIdRef.current = nextState;
+      return nextState;
+    });
+  };
+
+  const cacheFullBookInBackground = async (completeBookData) => {
+    try {
+      await saveFullBookPackage(completeBookData);
+      await enforceCacheBudget();
+    } catch (error) {
+      console.warn("Failed to cache full book package:", error);
+    }
+  };
 
   const upsertBookInLibrary = (bookData) => {
-    if (!bookData || !bookData.book_id) {
+    if (!bookData?.book_id) {
       return;
     }
 
@@ -29,20 +105,23 @@ const App = () => {
       const existingIndex = previousBooks.findIndex(
         (existingBook) => existingBook.book_id === bookData.book_id,
       );
+
+      const normalizedBook = {
+        book_id: bookData.book_id,
+        book_title: bookData.book_title,
+        json_url: bookData.json_url,
+        cover_url: bookData.cover?.url ?? bookData.cover_url ?? null,
+        images: bookData.images ?? [],
+        ...bookData,
+      };
+
       if (existingIndex >= 0) {
         const nextBooks = [...previousBooks];
-        nextBooks[existingIndex] = { ...nextBooks[existingIndex], ...bookData };
+        nextBooks[existingIndex] = { ...nextBooks[existingIndex], ...normalizedBook };
         return nextBooks;
       }
 
-      return [
-        {
-          book_id: bookData.book_id,
-          book_title: bookData.book_title,
-          ...bookData,
-        },
-        ...previousBooks,
-      ];
+      return [normalizedBook, ...previousBooks];
     });
   };
 
@@ -54,17 +133,21 @@ const App = () => {
     const fetchPromise = (async () => {
       setLibraryLoading(true);
       setLibraryError(false);
+
       try {
         const response = await fetch(buildApiUrl("/books/"), {
           method: "GET",
           headers: { "Content-Type": "application/json" },
         });
+
         if (!response.ok) {
           throw new Error(`Failed to fetch books. status=${response.status}`);
         }
 
         const books = await response.json();
-        setLibraryBooks(Array.isArray(books) ? books : []);
+        const normalizedBooks = Array.isArray(books) ? books : [];
+        setLibraryBooks(normalizedBooks);
+        await saveShelfMetadata(normalizedBooks);
       } catch (error) {
         console.error("Failed to prefetch library books:", error);
         setLibraryError(true);
@@ -74,6 +157,7 @@ const App = () => {
     })();
 
     libraryFetchPromiseRef.current = fetchPromise;
+
     try {
       await fetchPromise;
     } finally {
@@ -81,39 +165,229 @@ const App = () => {
     }
   };
 
-  useEffect(() => {
-    // Hydrate from cache immediately to avoid blank library on first open.
-    try {
-      const cachedLibraryRaw = localStorage.getItem(LIBRARY_CACHE_KEY);
-      if (cachedLibraryRaw) {
-        const parsed = JSON.parse(cachedLibraryRaw);
-        if (Array.isArray(parsed)) {
-          setLibraryBooks(parsed);
-        }
-      }
-    } catch (error) {
-      console.warn("Failed to hydrate cached library books:", error);
-    } finally {
-      setLibraryHydrated(true);
+  const fetchAndBuildFullBook = async (bookId) => {
+    const response = await fetch(buildApiUrl(`/books/${bookId}/`), {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch the selected book");
     }
 
-    // Always refresh in background; this does not block UI interactions.
+    const data = await response.json();
+    const bookDataResponse = await fetch(data.json_url);
+    if (!bookDataResponse.ok) {
+      throw new Error("Failed to fetch book data from json_url");
+    }
+
+    const bookData = await bookDataResponse.json();
+
+    return {
+      ...data,
+      ...bookData,
+      cover_url: data.cover?.url ?? data.cover_url ?? null,
+      images: data.images ?? bookData.images ?? [],
+    };
+  };
+
+  const pumpCoverQueue = async () => {
+    if (pendingCoverBookIdsRef.current.size >= COVER_DOWNLOAD_CONCURRENCY) {
+      return;
+    }
+
+    while (
+      pendingCoverBookIdsRef.current.size < COVER_DOWNLOAD_CONCURRENCY &&
+      coverQueueRef.current.length > 0
+    ) {
+      const nextTask = coverQueueRef.current.shift();
+      if (!nextTask?.bookId || !nextTask?.coverUrl) {
+        continue;
+      }
+
+      pendingCoverBookIdsRef.current.add(nextTask.bookId);
+      queuedCoverBookIdsRef.current.delete(nextTask.bookId);
+      markCoverStatus(nextTask.bookId, "pending");
+
+      cacheShelfCover({
+        bookId: nextTask.bookId,
+        sourceUrl: nextTask.coverUrl,
+      })
+        .then(async (objectUrl) => {
+          updateCoverState({
+            bookId: nextTask.bookId,
+            status: "cached",
+            sourceUrl: objectUrl,
+          });
+          await enforceCacheBudget();
+        })
+        .catch((error) => {
+          console.warn(`Failed to cache cover for ${nextTask.bookId}:`, error);
+          markCoverStatus(nextTask.bookId, "failed");
+        })
+        .finally(() => {
+          pendingCoverBookIdsRef.current.delete(nextTask.bookId);
+          void pumpCoverQueue();
+        });
+    }
+  };
+
+  useEffect(() => {
+    const cachedMetadata = loadShelfMetadataSync();
+    if (cachedMetadata?.books?.length) {
+      setLibraryBooks(cachedMetadata.books);
+    }
+
     fetchLibraryBooks();
   }, []);
 
   useEffect(() => {
-    if (!libraryHydrated) {
+    void saveShelfMetadata(libraryBooks);
+  }, [libraryBooks]);
+
+  useEffect(() => {
+    if (libraryBooks.length === 0) {
       return;
     }
 
-    try {
-      localStorage.setItem(LIBRARY_CACHE_KEY, JSON.stringify(libraryBooks));
-    } catch (error) {
-      console.warn("Failed to persist cached library books:", error);
-    }
-  }, [libraryBooks, libraryHydrated]);
+    const visibleSet = new Set(
+      visibleBookIds.length > 0
+        ? visibleBookIds
+        : libraryBooks.slice(0, INITIAL_VISIBLE_BOOK_COUNT).map((entry) => entry.book_id),
+    );
 
-  // Handler to generate a new book based on the theme
+    const visibleBooks = [];
+    const nearViewportBooks = [];
+    const visibleIndexes = [];
+
+    libraryBooks.forEach((bookEntry, index) => {
+      if (visibleSet.has(bookEntry.book_id)) {
+        visibleBooks.push(bookEntry);
+        visibleIndexes.push(index);
+        return;
+      }
+    });
+
+    const nearestVisibleIndex =
+      visibleIndexes.length > 0 ? Math.min(...visibleIndexes) : 0;
+    const furthestVisibleIndex =
+      visibleIndexes.length > 0 ? Math.max(...visibleIndexes) : INITIAL_VISIBLE_BOOK_COUNT - 1;
+
+    libraryBooks.forEach((bookEntry, index) => {
+      if (visibleSet.has(bookEntry.book_id)) {
+        return;
+      }
+
+      if (
+        index >= Math.max(0, nearestVisibleIndex - 4) &&
+        index <= Math.min(libraryBooks.length - 1, furthestVisibleIndex + 4)
+      ) {
+        nearViewportBooks.push(bookEntry);
+      }
+    });
+
+    const hydrateAndQueueCovers = async () => {
+      await Promise.all(
+        visibleBooks.map(async (bookEntry) => {
+          if (!bookEntry?.book_id || !bookEntry.cover_url) {
+            return;
+          }
+
+          if (coverStateByBookIdRef.current[bookEntry.book_id]?.status === "cached") {
+            return;
+          }
+
+          try {
+            const cachedCoverUrl = await getCachedShelfCover(bookEntry.book_id, bookEntry.cover_url);
+            if (cachedCoverUrl) {
+              updateCoverState({
+                bookId: bookEntry.book_id,
+                status: "cached",
+                sourceUrl: cachedCoverUrl,
+              });
+              return;
+            }
+
+            markCoverStatus(bookEntry.book_id, "uncached");
+          } catch (error) {
+            console.warn(`Failed to hydrate cached cover for ${bookEntry.book_id}:`, error);
+            markCoverStatus(bookEntry.book_id, "failed");
+          }
+        }),
+      );
+
+      const candidates = [];
+      for (const bookEntry of [...visibleBooks, ...nearViewportBooks]) {
+        if (!bookEntry?.book_id || !bookEntry.cover_url) {
+          continue;
+        }
+
+        const existingState = coverStateByBookIdRef.current[bookEntry.book_id];
+        if (existingState?.status === "cached" || existingState?.status === "pending") {
+          continue;
+        }
+
+        if (queuedCoverBookIdsRef.current.has(bookEntry.book_id)) {
+          continue;
+        }
+
+        const cached = await hasCachedShelfCover(bookEntry.book_id, bookEntry.cover_url);
+        if (cached) {
+          continue;
+        }
+
+        queuedCoverBookIdsRef.current.add(bookEntry.book_id);
+        candidates.push({
+          bookId: bookEntry.book_id,
+          coverUrl: bookEntry.cover_url,
+        });
+      }
+
+      if (candidates.length === 0) {
+        return;
+      }
+
+      coverQueueRef.current = [...candidates, ...coverQueueRef.current];
+      void pumpCoverQueue();
+    };
+
+    void hydrateAndQueueCovers();
+    // The queue runner is ref-driven and should not retrigger this effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [libraryBooks, visibleBookIds]);
+
+  const releaseAllCachedObjectUrls = () => {
+    releaseObjectUrls(Object.values(cachedCoverUrlsRef.current).filter(Boolean));
+    releaseObjectUrls(cachedBookObjectUrlsRef.current);
+  };
+
+  useEffect(() => {
+    return () => {
+      releaseAllCachedObjectUrls();
+    };
+  }, []);
+
+  const hydratedLibraryBooks = useMemo(
+    () =>
+      libraryBooks.map((bookEntry) => {
+        const coverState = coverStateByBookId[bookEntry.book_id];
+
+        return {
+          ...bookEntry,
+          render_cover_url: coverState?.url ?? null,
+          cover_cache_status: coverState?.status ?? (bookEntry.cover_url ? "uncached" : "missing"),
+        };
+      }),
+    [libraryBooks, coverStateByBookId],
+  );
+
+  const openBook = (nextBook) => {
+    releaseObjectUrls(cachedBookObjectUrlsRef.current);
+    cachedBookObjectUrlsRef.current = nextBook?.__cachedObjectUrls ?? [];
+    setBook(nextBook);
+    setIsModalOpen(true);
+  };
+
   const handleGenerateBook = async () => {
     if (!theme.trim()) {
       alert("Please enter a theme to generate a book.");
@@ -129,28 +403,28 @@ const App = () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ theme }),
       });
+
       if (!response.ok) {
         alert("Error generating book. Please try again.");
         return;
       }
-      const data = await response.json();
 
-      // Fetch the complete book data from json_url
+      const data = await response.json();
       const bookDataResponse = await fetch(data.json_url);
       if (!bookDataResponse.ok) {
         throw new Error("Failed to fetch book data from json_url");
       }
-      const bookData = await bookDataResponse.json();
 
-      // Combine the initial data with the fetched book data
+      const bookData = await bookDataResponse.json();
       const completeBookData = {
         ...data,
         ...bookData,
+        cover_url: data.cover?.url ?? data.cover_url ?? null,
       };
 
-      setBook(completeBookData);
+      openBook(completeBookData);
       upsertBookInLibrary(completeBookData);
-      setIsModalOpen(true);
+      void cacheFullBookInBackground(completeBookData);
     } catch (error) {
       console.error(error);
       setBook(null);
@@ -160,43 +434,28 @@ const App = () => {
     }
   };
 
-  // Handler to close the BookModal
   const handleCloseModal = () => {
+    releaseObjectUrls(cachedBookObjectUrlsRef.current);
+    cachedBookObjectUrlsRef.current = [];
     setIsModalOpen(false);
-    setBook(null); // Reset the book state
+    setBook(null);
   };
 
-  // Handler to fetch a book by ID (triggered from BookList)
   const handleSelectBook = async (bookId) => {
     setExistingBookLoading(true);
     setBook(null);
 
     try {
-      const response = await fetch(buildApiUrl(`/books/${bookId}/`), {
-        method: "GET",
-        headers: { "Content-Type": "application/json" },
-      });
-      if (!response.ok) {
-        throw new Error("Failed to fetch the selected book");
+      const cachedBook = await getCachedFullBook(bookId);
+      if (cachedBook) {
+        openBook(cachedBook);
+        return;
       }
-      const data = await response.json();
 
-      // Fetch the complete book data from json_url
-      const bookDataResponse = await fetch(data.json_url);
-      if (!bookDataResponse.ok) {
-        throw new Error("Failed to fetch book data from json_url");
-      }
-      const bookData = await bookDataResponse.json();
-
-      // Combine the initial data with the fetched book data
-      const completeBookData = {
-        ...data,
-        ...bookData,
-      };
-
-      setBook(completeBookData);
+      const completeBookData = await fetchAndBuildFullBook(bookId);
+      openBook(completeBookData);
       upsertBookInLibrary(completeBookData);
-      setIsModalOpen(true);
+      void cacheFullBookInBackground(completeBookData);
     } catch (error) {
       console.error(
         `App.js::handleSelectBook(): Failed to get book ID ${bookId} with error`,
@@ -220,14 +479,14 @@ const App = () => {
         loading={loading}
       />
       <BookList
-        books={libraryBooks}
-        loading={libraryLoading}
-        error={libraryError}
+        books={hydratedLibraryBooks}
+        loading={libraryLoading && libraryBooks.length === 0}
+        error={libraryError && libraryBooks.length === 0}
         onRetry={() => fetchLibraryBooks({ force: true })}
         onSelectBook={handleSelectBook}
+        onVisibleBooksChange={setVisibleBookIds}
       />
 
-      {/* Render the BookModal if a book is selected and modal is open */}
       {isModalOpen && book && (
         <BookModal
           book={book}
@@ -238,29 +497,25 @@ const App = () => {
   );
 };
 
-// Inline styles for simplicity
-const styles = {
+  const styles = {
   container: {
-    textAlign: "center",
-    padding: "20px",
-  },
-  button: {
-    padding: "10px 20px",
-    margin: "10px",
-    fontSize: "16px",
-    color: "#fff",
-    border: "none",
-    borderRadius: "4px",
+    minHeight: "100vh",
+    padding: "32px 20px 48px",
+    boxSizing: "border-box",
   },
   mainTitle: {
+    textAlign: "center",
     fontSize: "48px",
     margin: "0",
+    marginBottom: "8px",
     color: "#ffcc00",
     textShadow: "#FC0 1px 0 1px",
   },
   subTitle: {
+    textAlign: "center",
     fontSize: "24px",
-    margin: "10px 0",
+    marginTop: 0,
+    marginBottom: "24px",
     color: "#ffcc00",
     textShadow: "#FC0 1px 0 1px",
   },

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -6,7 +6,24 @@ jest.mock("./config", () => ({
   buildApiUrl: (path) => `http://localhost${path}`,
 }));
 
+const createDeferred = () => {
+  let resolvePromise;
+  let rejectPromise;
+
+  const promise = new Promise((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  return {
+    promise,
+    resolve: resolvePromise,
+    reject: rejectPromise,
+  };
+};
+
 beforeEach(() => {
+  window.localStorage.clear();
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => [],
@@ -43,4 +60,86 @@ test("renders the app header and library entry point", async () => {
       headers: { "Content-Type": "application/json" },
     });
   });
+});
+
+test("renders cached shelf metadata before the background refresh resolves", async () => {
+  window.localStorage.setItem(
+    "kwento_shelf_metadata_v1",
+    JSON.stringify({
+      version: 1,
+      books: [
+        {
+          book_id: "cached-book-1",
+          book_title: "Cached Shelf Book",
+          cover_url: "https://example.com/cached-cover.png",
+        },
+      ],
+      updatedAt: Date.now(),
+      expiresAt: Date.now() + 1000,
+    }),
+  );
+
+  const booksRequest = createDeferred();
+  global.fetch.mockReturnValue(booksRequest.promise);
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  expect(screen.getByRole("button", { name: /cached shelf book/i })).toBeInTheDocument();
+  expect(global.fetch).toHaveBeenCalledWith("http://localhost/books/", {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  await act(async () => {
+    booksRequest.resolve({
+      ok: true,
+      json: async () => [
+        {
+          book_id: "remote-book-1",
+          book_title: "Remote Shelf Book",
+        },
+      ],
+    });
+  });
+
+  await waitFor(() => {
+    expect(screen.getByRole("button", { name: /remote shelf book/i })).toBeInTheDocument();
+  });
+});
+
+test("keeps cached shelf metadata visible when the background refresh fails", async () => {
+  window.localStorage.setItem(
+    "kwento_shelf_metadata_v1",
+    JSON.stringify({
+      version: 1,
+      books: [
+        {
+          book_id: "cached-book-2",
+          book_title: "Offline Shelf Book",
+        },
+      ],
+      updatedAt: Date.now(),
+      expiresAt: Date.now() + 1000,
+    }),
+  );
+
+  global.fetch.mockRejectedValue(new Error("network down"));
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  expect(screen.getByRole("button", { name: /offline shelf book/i })).toBeInTheDocument();
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith("http://localhost/books/", {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  expect(screen.queryByText(/error fetching books/i)).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /offline shelf book/i })).toBeInTheDocument();
 });

--- a/frontend/src/cache/libraryCache.js
+++ b/frontend/src/cache/libraryCache.js
@@ -1,0 +1,443 @@
+const CACHE_VERSION = 1;
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const DB_NAME = "kwento-cache";
+const DB_VERSION = 1;
+const ASSETS_STORE = "assets";
+const BOOKS_STORE = "books";
+const METADATA_KEY = "kwento_shelf_metadata_v1";
+
+const CACHE_CLASS_SHELF_COVER = "shelf-cover";
+const CACHE_CLASS_FULL_BOOK = "full-book";
+
+let dbPromise = null;
+
+const hasLocalStorage = () => typeof window !== "undefined" && window.localStorage;
+const hasIndexedDb = () => typeof window !== "undefined" && window.indexedDB;
+
+const now = () => Date.now();
+
+const withExpiry = (value = {}) => {
+  const updatedAt = value.updatedAt ?? now();
+  return {
+    ...value,
+    updatedAt,
+    expiresAt: value.expiresAt ?? updatedAt + TTL_MS,
+  };
+};
+
+const readLocalStorageJson = (key) => {
+  if (!hasLocalStorage()) {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch (error) {
+    console.warn(`Failed to parse cache entry for ${key}:`, error);
+    return null;
+  }
+};
+
+const writeLocalStorageJson = (key, value) => {
+  if (!hasLocalStorage()) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn(`Failed to persist cache entry for ${key}:`, error);
+  }
+};
+
+const openDatabase = () => {
+  if (!hasIndexedDb()) {
+    return Promise.resolve(null);
+  }
+
+  if (dbPromise) {
+    return dbPromise;
+  }
+
+  dbPromise = new Promise((resolve, reject) => {
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+
+      if (!db.objectStoreNames.contains(ASSETS_STORE)) {
+        const assetsStore = db.createObjectStore(ASSETS_STORE, { keyPath: "id" });
+        assetsStore.createIndex("cacheClass", "cacheClass", { unique: false });
+        assetsStore.createIndex("lastUsedAt", "lastUsedAt", { unique: false });
+        assetsStore.createIndex("updatedAt", "updatedAt", { unique: false });
+      }
+
+      if (!db.objectStoreNames.contains(BOOKS_STORE)) {
+        const booksStore = db.createObjectStore(BOOKS_STORE, { keyPath: "id" });
+        booksStore.createIndex("cacheClass", "cacheClass", { unique: false });
+        booksStore.createIndex("lastUsedAt", "lastUsedAt", { unique: false });
+        booksStore.createIndex("updatedAt", "updatedAt", { unique: false });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+  return dbPromise;
+};
+
+const runTransaction = async (storeName, mode, operation) => {
+  const db = await openDatabase();
+  if (!db) {
+    return null;
+  }
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(storeName, mode);
+    const store = transaction.objectStore(storeName);
+    const request = operation(store);
+
+    if (!request) {
+      transaction.oncomplete = () => resolve(null);
+      transaction.onerror = () => reject(transaction.error);
+      return;
+    }
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+};
+
+const putRecord = (storeName, value) =>
+  runTransaction(storeName, "readwrite", (store) => store.put(value));
+
+const getRecord = (storeName, key) =>
+  runTransaction(storeName, "readonly", (store) => store.get(key));
+
+const deleteRecord = (storeName, key) =>
+  runTransaction(storeName, "readwrite", (store) => store.delete(key));
+
+const getAllRecords = (storeName) =>
+  runTransaction(storeName, "readonly", (store) => store.getAll());
+
+const safeFetchBlob = async (url) => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch asset. status=${response.status}`);
+  }
+
+  return response.blob();
+};
+
+const shelfCoverKey = (bookId) => `cover:${bookId}`;
+const fullBookKey = (bookId) => `book:${bookId}`;
+
+const isExpired = (entry) => Boolean(entry?.expiresAt && entry.expiresAt < now());
+
+const approximateBlobSize = (blob) => blob?.size ?? 0;
+const toObjectUrl = (blob, fallbackUrl = null) => {
+  if (typeof URL?.createObjectURL !== "function") {
+    return fallbackUrl;
+  }
+
+  return URL.createObjectURL(blob);
+};
+
+const estimateRecordSize = (record) => {
+  if (!record) {
+    return 0;
+  }
+
+  if (record.blob) {
+    return approximateBlobSize(record.blob);
+  }
+
+  try {
+    return new Blob([JSON.stringify(record)]).size;
+  } catch (error) {
+    return 0;
+  }
+};
+
+export const loadShelfMetadataSync = () => {
+  const entry = readLocalStorageJson(METADATA_KEY);
+  if (!entry || entry.version !== CACHE_VERSION || !Array.isArray(entry.books)) {
+    return null;
+  }
+
+  return entry;
+};
+
+export const saveShelfMetadata = async (books) => {
+  const entry = withExpiry({
+    version: CACHE_VERSION,
+    books: Array.isArray(books) ? books : [],
+  });
+
+  writeLocalStorageJson(METADATA_KEY, entry);
+  return entry;
+};
+
+export const getCachedShelfCover = async (bookId, sourceUrl) => {
+  const entry = await getRecord(ASSETS_STORE, shelfCoverKey(bookId));
+  if (!entry || !entry.blob || isExpired(entry)) {
+    return null;
+  }
+
+  if (sourceUrl && entry.sourceUrl && entry.sourceUrl !== sourceUrl) {
+    return null;
+  }
+
+  entry.lastUsedAt = now();
+  await putRecord(ASSETS_STORE, entry);
+  return toObjectUrl(entry.blob, entry.sourceUrl ?? sourceUrl);
+};
+
+export const hasCachedShelfCover = async (bookId, sourceUrl) => {
+  const entry = await getRecord(ASSETS_STORE, shelfCoverKey(bookId));
+  if (!entry || !entry.blob || isExpired(entry)) {
+    return false;
+  }
+
+  return !sourceUrl || !entry.sourceUrl || entry.sourceUrl === sourceUrl;
+};
+
+export const cacheShelfCover = async ({ bookId, sourceUrl }) => {
+  if (!bookId || !sourceUrl) {
+    return null;
+  }
+
+  const db = await openDatabase();
+  if (!db) {
+    return sourceUrl;
+  }
+
+  const existing = await getRecord(ASSETS_STORE, shelfCoverKey(bookId));
+  if (existing?.blob && !isExpired(existing) && existing.sourceUrl === sourceUrl) {
+    existing.lastUsedAt = now();
+    await putRecord(ASSETS_STORE, existing);
+    return toObjectUrl(existing.blob, existing.sourceUrl);
+  }
+
+  const blob = await safeFetchBlob(sourceUrl);
+  const entry = withExpiry({
+    id: shelfCoverKey(bookId),
+    bookId,
+    sourceUrl,
+    blob,
+    cacheClass: CACHE_CLASS_SHELF_COVER,
+    lastUsedAt: now(),
+  });
+
+  await putRecord(ASSETS_STORE, entry);
+  return toObjectUrl(blob, sourceUrl);
+};
+
+const buildFullBookAssetEntries = async (book) => {
+  const assetDescriptors = [];
+  const coverUrl = book.cover?.url ?? book.cover_url ?? null;
+
+  if (coverUrl) {
+    assetDescriptors.push({
+      key: `${fullBookKey(book.book_id)}:cover`,
+      type: "cover",
+      page: null,
+      sourceUrl: coverUrl,
+    });
+  }
+
+  for (const image of book.images ?? []) {
+    if (!image?.url || typeof image.page !== "number") {
+      continue;
+    }
+
+    assetDescriptors.push({
+      key: `${fullBookKey(book.book_id)}:image:${image.page}`,
+      type: "image",
+      page: image.page,
+      sourceUrl: image.url,
+    });
+  }
+
+  const assets = await Promise.all(
+    assetDescriptors.map(async (asset) => {
+      const blob = await safeFetchBlob(asset.sourceUrl);
+      const entry = withExpiry({
+        id: asset.key,
+        bookId: book.book_id,
+        page: asset.page,
+        sourceUrl: asset.sourceUrl,
+        blob,
+        cacheClass: CACHE_CLASS_FULL_BOOK,
+        assetType: asset.type,
+        lastUsedAt: now(),
+      });
+
+      await putRecord(ASSETS_STORE, entry);
+      return {
+        key: asset.key,
+        type: asset.type,
+        page: asset.page,
+        sourceUrl: asset.sourceUrl,
+      };
+    }),
+  );
+
+  return assets;
+};
+
+export const saveFullBookPackage = async (book) => {
+  if (!book?.book_id) {
+    return null;
+  }
+
+  const db = await openDatabase();
+  if (!db) {
+    return null;
+  }
+
+  const assets = await buildFullBookAssetEntries(book);
+  const packageRecord = withExpiry({
+    id: fullBookKey(book.book_id),
+    bookId: book.book_id,
+    cacheClass: CACHE_CLASS_FULL_BOOK,
+    lastUsedAt: now(),
+    package: {
+      ...book,
+      cachedAt: now(),
+    },
+    assets,
+  });
+
+  await putRecord(BOOKS_STORE, packageRecord);
+  return packageRecord;
+};
+
+export const getCachedFullBook = async (bookId) => {
+  const db = await openDatabase();
+  if (!db) {
+    return null;
+  }
+
+  const packageRecord = await getRecord(BOOKS_STORE, fullBookKey(bookId));
+  if (!packageRecord || !packageRecord.package || isExpired(packageRecord)) {
+    return null;
+  }
+
+  const assets = await Promise.all(
+    (packageRecord.assets ?? []).map(async (asset) => {
+      const entry = await getRecord(ASSETS_STORE, asset.key);
+      if (!entry?.blob || isExpired(entry)) {
+        return null;
+      }
+
+      entry.lastUsedAt = now();
+      await putRecord(ASSETS_STORE, entry);
+      return {
+        ...asset,
+        objectUrl: toObjectUrl(entry.blob, entry.sourceUrl),
+      };
+    }),
+  );
+
+  if (assets.some((asset) => asset === null)) {
+    return null;
+  }
+
+  packageRecord.lastUsedAt = now();
+  await putRecord(BOOKS_STORE, packageRecord);
+
+  const coverAsset = assets.find((asset) => asset.type === "cover");
+  const imageAssetsByPage = new Map(
+    assets.filter((asset) => asset.type === "image").map((asset) => [asset.page, asset.objectUrl]),
+  );
+
+  return {
+    ...packageRecord.package,
+    cover: packageRecord.package.cover
+      ? {
+          ...packageRecord.package.cover,
+          url: coverAsset?.objectUrl ?? packageRecord.package.cover.url,
+        }
+      : packageRecord.package.cover,
+    cover_url: coverAsset?.objectUrl ?? packageRecord.package.cover_url,
+    images: (packageRecord.package.images ?? []).map((image) => ({
+      ...image,
+      url: imageAssetsByPage.get(image.page) ?? image.url,
+    })),
+    __cachedObjectUrls: assets.map((asset) => asset.objectUrl),
+  };
+};
+
+const deleteEntries = async (entries) => {
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (entry.storeName && entry.id) {
+        await deleteRecord(entry.storeName, entry.id);
+      }
+    }),
+  );
+};
+
+export const enforceCacheBudget = async ({ maxBytes = 500 * 1024 * 1024 } = {}) => {
+  const [assetRecords, bookRecords] = await Promise.all([
+    getAllRecords(ASSETS_STORE),
+    getAllRecords(BOOKS_STORE),
+  ]);
+
+  const assets = assetRecords ?? [];
+  const books = bookRecords ?? [];
+  const metadata = loadShelfMetadataSync();
+  const metadataSize = metadata ? estimateRecordSize(metadata) : 0;
+
+  const candidates = [
+    ...books.map((entry) => ({ ...entry, storeName: BOOKS_STORE, size: estimateRecordSize(entry) })),
+    ...assets.map((entry) => ({ ...entry, storeName: ASSETS_STORE, size: estimateRecordSize(entry) })),
+  ];
+
+  let totalSize = metadataSize + candidates.reduce((sum, entry) => sum + entry.size, 0);
+  if (totalSize <= maxBytes) {
+    return;
+  }
+
+  const evictionPriority = (entry) => {
+    if (entry.cacheClass === CACHE_CLASS_FULL_BOOK) {
+      return 0;
+    }
+
+    if (entry.cacheClass === CACHE_CLASS_SHELF_COVER) {
+      return 1;
+    }
+
+    return 2;
+  };
+
+  const evictableEntries = candidates.sort((left, right) => {
+    const classDelta = evictionPriority(left) - evictionPriority(right);
+    if (classDelta !== 0) {
+      return classDelta;
+    }
+
+    const leftExpired = isExpired(left) ? 0 : 1;
+    const rightExpired = isExpired(right) ? 0 : 1;
+    if (leftExpired !== rightExpired) {
+      return leftExpired - rightExpired;
+    }
+
+    return (left.lastUsedAt ?? left.updatedAt ?? 0) - (right.lastUsedAt ?? right.updatedAt ?? 0);
+  });
+
+  const removals = [];
+  for (const entry of evictableEntries) {
+    if (totalSize <= maxBytes) {
+      break;
+    }
+
+    removals.push(entry);
+    totalSize -= entry.size;
+  }
+
+  await deleteEntries(removals);
+};

--- a/frontend/src/components/BookList.js
+++ b/frontend/src/components/BookList.js
@@ -1,6 +1,6 @@
 // kwento/frontend/src/components/BookList.js
 
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 const BOOK_SHELF_TAB = "bookshelf";
 const ARCHIVE_TAB = "archive";
@@ -37,8 +37,16 @@ const BookCoverImage = ({ coverUrl, bookTitle, onSizeChange }) => {
   );
 };
 
-const BookList = ({ books, loading, error, onRetry, onSelectBook }) => {
+const BookList = ({
+  books,
+  loading,
+  error,
+  onRetry,
+  onSelectBook,
+  onVisibleBooksChange,
+}) => {
   const buttonRefs = useRef({});
+  const itemRefs = useRef({});
   const [maxButtonHeight, setMaxButtonHeight] = useState(null);
   const [layoutVersion, setLayoutVersion] = useState(0);
   const [activeTab, setActiveTab] = useState(BOOK_SHELF_TAB);
@@ -78,6 +86,59 @@ const BookList = ({ books, loading, error, onRetry, onSelectBook }) => {
     };
   }, []);
 
+  useEffect(() => {
+    if (typeof onVisibleBooksChange !== "function") {
+      return undefined;
+    }
+
+    if (activeTab !== BOOK_SHELF_TAB || books.length === 0) {
+      onVisibleBooksChange([]);
+      return undefined;
+    }
+
+    if (typeof window === "undefined" || typeof window.IntersectionObserver !== "function") {
+      onVisibleBooksChange(books.slice(0, 6).map((book) => book.book_id));
+      return undefined;
+    }
+
+    const visibleBookIds = new Set();
+    const observer = new window.IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const { bookId } = entry.target.dataset;
+          if (!bookId) {
+            return;
+          }
+
+          if (entry.isIntersecting) {
+            visibleBookIds.add(bookId);
+            return;
+          }
+
+          visibleBookIds.delete(bookId);
+        });
+
+        onVisibleBooksChange(Array.from(visibleBookIds));
+      },
+      {
+        root: null,
+        rootMargin: "240px 0px",
+        threshold: 0.01,
+      },
+    );
+
+    books.forEach((book) => {
+      const element = itemRefs.current[book.book_id];
+      if (element) {
+        observer.observe(element);
+      }
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [activeTab, books, onVisibleBooksChange]);
+
   const handleSizeChange = () => {
     setLayoutVersion((currentVersion) => currentVersion + 1);
   };
@@ -105,7 +166,19 @@ const BookList = ({ books, loading, error, onRetry, onSelectBook }) => {
     return (
       <ul style={styles.list}>
         {books.map((book) => (
-          <li key={book.book_id} style={styles.listItem}>
+          <li
+            key={book.book_id}
+            style={styles.listItem}
+            data-book-id={book.book_id}
+            ref={(element) => {
+              if (element) {
+                itemRefs.current[book.book_id] = element;
+                return;
+              }
+
+              delete itemRefs.current[book.book_id];
+            }}
+          >
             <button
               ref={(element) => {
                 if (element) {
@@ -126,7 +199,7 @@ const BookList = ({ books, loading, error, onRetry, onSelectBook }) => {
               <span style={styles.bookTitle}>{book.book_title}</span>
               <div style={styles.coverSlot}>
                 <BookCoverImage
-                  coverUrl={book.cover_url}
+                  coverUrl={book.render_cover_url}
                   bookTitle={book.book_title}
                   onSizeChange={handleSizeChange}
                 />

--- a/frontend/src/components/BookList.test.js
+++ b/frontend/src/components/BookList.test.js
@@ -81,6 +81,7 @@ describe("BookList", () => {
         book_id: "book-2",
         book_title: "The Cover Book",
         cover_url: "https://example.com/cover.png",
+        render_cover_url: "blob:cached-cover",
       },
     ]);
 
@@ -101,11 +102,12 @@ describe("BookList", () => {
     });
   });
 
-  test("renders title-only when cover_url is missing", () => {
+  test("renders title-only when no cached shelf cover is available", () => {
     renderBookList([
       {
         book_id: "book-3",
         book_title: "Title Only",
+        cover_url: "https://example.com/remote-cover.png",
       },
     ]);
 
@@ -119,6 +121,7 @@ describe("BookList", () => {
         book_id: "book-4",
         book_title: "Broken Cover",
         cover_url: "https://example.com/broken-cover.png",
+        render_cover_url: "blob:broken-cover",
       },
     ]);
 


### PR DESCRIPTION
Implemented shelf-first caching so repeat visits paint the Book Shelf from local data immediately instead of waiting on /books/ or on cover downloads. The client now separates shelf metadata, per-cover shelf assets, and full-book packages into independent caches. On startup, cached shelf metadata hydrates first, the shelf renders immediately, and /books/ refreshes in the background. Opened and generated books still use the full-book cache path.

The shelf cover behavior was also rebuilt around partial success. Covers are now cached independently, hydrated only when already cached, and background cover work is prioritized to visible and near-viewport books with small concurrency. Shelf cards no longer fall back to remote original cover URLs during initial render, which prevents the browser from issuing dozens of large image requests just to paint the shelf. That change also removed the interaction stall you observed, so second-load shelf rendering is faster and book cards remain clickable while background refresh work continues.

For users, the outcome is:

repeat visits show the book list immediately from cache
cached covers appear when available without blocking first paint
uncached covers no longer slow down or freeze the shelf
opening a previously cached book can reuse local full-book data
the app remains responsive while metadata and covers refresh in the background
Validation:

updated app and component tests for cached shelf startup and partial-cover rendering
npm test -- --watch=false
npm run build