### PR TITLE
IDBDatabase bug fix

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -47,6 +47,7 @@ const App = () => {
   const coverQueueRef = useRef([]);
   const queuedCoverBookIdsRef = useRef(new Set());
   const pendingCoverBookIdsRef = useRef(new Set());
+  const inFlightBookSelectionRef = useRef(new Map());
 
   const updateCoverState = ({ bookId, status, sourceUrl }) => {
     setCoverStateByBookId((currentState) => {
@@ -442,30 +443,51 @@ const App = () => {
   };
 
   const handleSelectBook = async (bookId) => {
-    setExistingBookLoading(true);
-    setBook(null);
+    if (!bookId) {
+      return;
+    }
+
+    const existingSelection = inFlightBookSelectionRef.current.get(bookId);
+    if (existingSelection) {
+      return existingSelection;
+    }
+
+    const selectionPromise = (async () => {
+      setExistingBookLoading(true);
+      setBook(null);
+
+      try {
+        const cachedBook = await getCachedFullBook(bookId);
+        if (cachedBook) {
+          openBook(cachedBook);
+          return;
+        }
+
+        const completeBookData = await fetchAndBuildFullBook(bookId);
+        openBook(completeBookData);
+        upsertBookInLibrary(completeBookData);
+        void cacheFullBookInBackground(completeBookData);
+      } catch (error) {
+        console.error(
+          `App.js::handleSelectBook(): Failed to get book ID ${bookId} with error`,
+          error,
+        );
+        setBook(null);
+        alert("Error fetching the book. Please try again.");
+      } finally {
+        setExistingBookLoading(false);
+      }
+    })();
+
+    inFlightBookSelectionRef.current.set(bookId, selectionPromise);
 
     try {
-      const cachedBook = await getCachedFullBook(bookId);
-      if (cachedBook) {
-        openBook(cachedBook);
-        return;
-      }
-
-      const completeBookData = await fetchAndBuildFullBook(bookId);
-      openBook(completeBookData);
-      upsertBookInLibrary(completeBookData);
-      void cacheFullBookInBackground(completeBookData);
-    } catch (error) {
-      console.error(
-        `App.js::handleSelectBook(): Failed to get book ID ${bookId} with error`,
-        error,
-      );
-      setBook(null);
-      alert("Error fetching the book. Please try again.");
+      await selectionPromise;
     } finally {
-      setExistingBookLoading(false);
+      inFlightBookSelectionRef.current.delete(bookId);
     }
+
+    return selectionPromise;
   };
 
   return (

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,9 +1,29 @@
 import { act } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import App from "./App";
+
+const mockCacheShelfCover = jest.fn();
+const mockEnforceCacheBudget = jest.fn();
+const mockGetCachedFullBook = jest.fn();
+const mockGetCachedShelfCover = jest.fn();
+const mockHasCachedShelfCover = jest.fn();
+const mockLoadShelfMetadataSync = jest.fn();
+const mockSaveFullBookPackage = jest.fn();
+const mockSaveShelfMetadata = jest.fn();
 
 jest.mock("./config", () => ({
   buildApiUrl: (path) => `http://localhost${path}`,
+}));
+
+jest.mock("./cache/libraryCache", () => ({
+  cacheShelfCover: (...args) => mockCacheShelfCover(...args),
+  enforceCacheBudget: (...args) => mockEnforceCacheBudget(...args),
+  getCachedFullBook: (...args) => mockGetCachedFullBook(...args),
+  getCachedShelfCover: (...args) => mockGetCachedShelfCover(...args),
+  hasCachedShelfCover: (...args) => mockHasCachedShelfCover(...args),
+  loadShelfMetadataSync: (...args) => mockLoadShelfMetadataSync(...args),
+  saveFullBookPackage: (...args) => mockSaveFullBookPackage(...args),
+  saveShelfMetadata: (...args) => mockSaveShelfMetadata(...args),
 }));
 
 const createDeferred = () => {
@@ -24,6 +44,17 @@ const createDeferred = () => {
 
 beforeEach(() => {
   window.localStorage.clear();
+  mockCacheShelfCover.mockResolvedValue(null);
+  mockEnforceCacheBudget.mockResolvedValue(undefined);
+  mockGetCachedFullBook.mockResolvedValue(null);
+  mockGetCachedShelfCover.mockResolvedValue(null);
+  mockHasCachedShelfCover.mockResolvedValue(false);
+  mockLoadShelfMetadataSync.mockImplementation(() => {
+    const raw = window.localStorage.getItem("kwento_shelf_metadata_v1");
+    return raw ? JSON.parse(raw) : null;
+  });
+  mockSaveFullBookPackage.mockResolvedValue(undefined);
+  mockSaveShelfMetadata.mockResolvedValue(undefined);
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => [],
@@ -142,4 +173,62 @@ test("keeps cached shelf metadata visible when the background refresh fails", as
 
   expect(screen.queryByText(/error fetching books/i)).not.toBeInTheDocument();
   expect(screen.getByRole("button", { name: /offline shelf book/i })).toBeInTheDocument();
+});
+
+test("deduplicates repeated clicks while the same book is still opening", async () => {
+  const bookDetailsRequest = createDeferred();
+
+  global.fetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          book_id: "book-1",
+          book_title: "Repeat Click Book",
+          json_url: "https://example.com/book-1.json",
+        },
+      ],
+    })
+    .mockReturnValueOnce(bookDetailsRequest.promise)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        pages: [{ page: 1, text: "Once upon a time" }],
+      }),
+    });
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  const bookButton = await screen.findByRole("button", { name: /repeat click book/i });
+
+  await act(async () => {
+    fireEvent.click(bookButton);
+    fireEvent.click(bookButton);
+    fireEvent.click(bookButton);
+  });
+
+  expect(mockGetCachedFullBook).toHaveBeenCalledTimes(1);
+  expect(global.fetch).toHaveBeenCalledTimes(2);
+  expect(global.fetch).toHaveBeenNthCalledWith(2, "http://localhost/books/book-1/", {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  await act(async () => {
+    bookDetailsRequest.resolve({
+      ok: true,
+      json: async () => ({
+        book_id: "book-1",
+        book_title: "Repeat Click Book",
+        json_url: "https://example.com/book-1.json",
+        images: [],
+      }),
+    });
+  });
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
 });

--- a/frontend/src/cache/libraryCache.js
+++ b/frontend/src/cache/libraryCache.js
@@ -51,6 +51,43 @@ const writeLocalStorageJson = (key, value) => {
   }
 };
 
+const resetDatabasePromise = () => {
+  dbPromise = null;
+};
+
+const isRecoverableDatabaseError = (error) => {
+  if (!error) {
+    return false;
+  }
+
+  const errorName = error.name ?? "";
+  const errorMessage = error.message ?? "";
+
+  return (
+    errorName === "InvalidStateError" ||
+    errorName === "AbortError" ||
+    errorMessage.includes("connection is closing") ||
+    errorMessage.includes("database connection is closing")
+  );
+};
+
+const attachDatabaseLifecycleHandlers = (db) => {
+  if (!db) {
+    return;
+  }
+
+  db.onversionchange = () => {
+    resetDatabasePromise();
+    db.close();
+  };
+
+  if ("onclose" in db) {
+    db.onclose = () => {
+      resetDatabasePromise();
+    };
+  }
+};
+
 const openDatabase = () => {
   if (!hasIndexedDb()) {
     return Promise.resolve(null);
@@ -81,33 +118,66 @@ const openDatabase = () => {
       }
     };
 
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const db = request.result;
+      attachDatabaseLifecycleHandlers(db);
+      resolve(db);
+    };
+
+    request.onerror = () => {
+      resetDatabasePromise();
+      reject(request.error);
+    };
+
+    request.onblocked = () => {
+      resetDatabasePromise();
+    };
   });
 
   return dbPromise;
 };
 
-const runTransaction = async (storeName, mode, operation) => {
-  const db = await openDatabase();
-  if (!db) {
-    return null;
-  }
-
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(storeName, mode);
-    const store = transaction.objectStore(storeName);
-    const request = operation(store);
-
-    if (!request) {
-      transaction.oncomplete = () => resolve(null);
-      transaction.onerror = () => reject(transaction.error);
-      return;
+const runTransaction = async (storeName, mode, operation, retryCount = 1) => {
+  try {
+    const db = await openDatabase();
+    if (!db) {
+      return null;
     }
 
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
-  });
+    return await new Promise((resolve, reject) => {
+      let request = null;
+      let resolved = false;
+      const transaction = db.transaction(storeName, mode);
+      const store = transaction.objectStore(storeName);
+
+      transaction.oncomplete = () => {
+        if (!resolved) {
+          resolve(request?.result ?? null);
+        }
+      };
+
+      transaction.onerror = () => reject(transaction.error);
+      transaction.onabort = () => reject(transaction.error);
+
+      request = operation(store);
+      if (!request) {
+        return;
+      }
+
+      request.onsuccess = () => {
+        resolved = true;
+        resolve(request.result);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } catch (error) {
+    if (retryCount > 0 && isRecoverableDatabaseError(error)) {
+      resetDatabasePromise();
+      return runTransaction(storeName, mode, operation, retryCount - 1);
+    }
+
+    throw error;
+  }
 };
 
 const putRecord = (storeName, value) =>


### PR DESCRIPTION
Updated the frontend to make bookshelf book opens resilient under repeated user clicks and transient IndexedDB connection shutdowns.

This PR hardens the client-side cache layer by resetting and reopening the shared IndexedDB connection when the browser reports a closing/invalid database state, then retrying the affected transaction once. It also deduplicates in-flight book-open requests per bookId, so repeated clicks on the same bookshelf card no longer trigger overlapping cache reads and fetches. Added a regression test covering repeated clicks during book open, and the full frontend test suite passes.


