### PR TITLE
Standard image caching path to eliminate iOS Safari blob-related imag…

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,22 +1,16 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import ThemeInput from "./components/ThemeInput";
 import BookModal from "./components/BookModal";
 import BookList from "./components/BookList";
 import { buildApiUrl } from "./config";
 import {
-  cacheShelfCover,
   enforceCacheBudget,
   getCachedFullBook,
-  getCachedShelfCover,
-  hasCachedShelfCover,
   loadShelfMetadataSync,
   saveFullBookPackage,
   saveShelfMetadata,
 } from "./cache/libraryCache";
 import { getImageDebugPageContext, logImageEvent } from "./debug/imageDebug";
-
-const COVER_DOWNLOAD_CONCURRENCY = 3;
-const INITIAL_VISIBLE_BOOK_COUNT = 6;
 
 const releaseObjectUrls = (urls = []) => {
   if (typeof URL?.revokeObjectURL !== "function") {
@@ -39,71 +33,26 @@ const App = () => {
   const [libraryBooks, setLibraryBooks] = useState([]);
   const [libraryLoading, setLibraryLoading] = useState(false);
   const [libraryError, setLibraryError] = useState(false);
-  const [visibleBookIds, setVisibleBookIds] = useState([]);
-  const [coverStateByBookId, setCoverStateByBookId] = useState({});
+  const [, setVisibleBookIds] = useState([]);
   const libraryFetchPromiseRef = useRef(null);
-  const cachedCoverUrlsRef = useRef({});
   const cachedBookObjectUrlsRef = useRef([]);
-  const coverStateByBookIdRef = useRef({});
-  const previousCoverUrlsRef = useRef({});
   const previousBookObjectUrlsRef = useRef([]);
-  const coverQueueRef = useRef([]);
-  const queuedCoverBookIdsRef = useRef(new Set());
-  const pendingCoverBookIdsRef = useRef(new Set());
   const inFlightBookSelectionRef = useRef(new Map());
-
-  const updateCoverState = ({ bookId, status, sourceUrl }) => {
-    setCoverStateByBookId((currentState) => {
-      cachedCoverUrlsRef.current[bookId] = sourceUrl ?? null;
-      const previousState = currentState[bookId] ?? null;
-
-      const nextState = {
-        ...currentState,
-        [bookId]: {
-          status,
-          url: sourceUrl ?? null,
-        },
-      };
-
-      logImageEvent("cover:state_updated", {
-        book_id: bookId,
-        previous_status: previousState?.status ?? null,
-        next_status: status,
-        render_cover_url: sourceUrl ?? null,
-      });
-      coverStateByBookIdRef.current = nextState;
-      return nextState;
-    });
-  };
-
-  const markCoverStatus = (bookId, status) => {
-    setCoverStateByBookId((currentState) => {
-      const previousState = currentState[bookId] ?? null;
-      const nextState = {
-        ...currentState,
-        [bookId]: {
-          ...(currentState[bookId] ?? {}),
-          status,
-        },
-      };
-
-      logImageEvent("cover:status_marked", {
-        book_id: bookId,
-        previous_status: previousState?.status ?? null,
-        next_status: status,
-        render_cover_url: previousState?.url ?? null,
-      });
-      coverStateByBookIdRef.current = nextState;
-      return nextState;
-    });
-  };
 
   const cacheFullBookInBackground = async (completeBookData) => {
     try {
       await saveFullBookPackage(completeBookData);
       await enforceCacheBudget();
+      logImageEvent("full_book:cache_saved", {
+        book_id: completeBookData.book_id,
+        image_count: completeBookData.images?.length ?? 0,
+      });
     } catch (error) {
       console.warn("Failed to cache full book package:", error);
+      logImageEvent("full_book:cache_save_error", {
+        book_id: completeBookData?.book_id ?? null,
+        error,
+      });
     }
   };
 
@@ -211,72 +160,6 @@ const App = () => {
     };
   };
 
-  const pumpCoverQueue = async () => {
-    if (pendingCoverBookIdsRef.current.size >= COVER_DOWNLOAD_CONCURRENCY) {
-      logImageEvent("cover:queue_backpressure", {
-        pending_count: pendingCoverBookIdsRef.current.size,
-        queued_count: coverQueueRef.current.length,
-      });
-      return;
-    }
-
-    while (
-      pendingCoverBookIdsRef.current.size < COVER_DOWNLOAD_CONCURRENCY &&
-      coverQueueRef.current.length > 0
-    ) {
-      const nextTask = coverQueueRef.current.shift();
-      if (!nextTask?.bookId || !nextTask?.coverUrl) {
-        continue;
-      }
-
-      pendingCoverBookIdsRef.current.add(nextTask.bookId);
-      queuedCoverBookIdsRef.current.delete(nextTask.bookId);
-      logImageEvent("cover:queue_dequeued", {
-        book_id: nextTask.bookId,
-        source_url: nextTask.coverUrl,
-        pending_count: pendingCoverBookIdsRef.current.size,
-        queued_count: coverQueueRef.current.length,
-      });
-      markCoverStatus(nextTask.bookId, "pending");
-
-      cacheShelfCover({
-        bookId: nextTask.bookId,
-        sourceUrl: nextTask.coverUrl,
-      })
-        .then(async (objectUrl) => {
-          logImageEvent("cover:queue_resolved", {
-            book_id: nextTask.bookId,
-            source_url: nextTask.coverUrl,
-            render_cover_url: objectUrl,
-          });
-          updateCoverState({
-            bookId: nextTask.bookId,
-            status: "cached",
-            sourceUrl: objectUrl,
-          });
-          await enforceCacheBudget();
-        })
-        .catch((error) => {
-          console.warn(`Failed to cache cover for ${nextTask.bookId}:`, error);
-          logImageEvent("cover:queue_failed", {
-            book_id: nextTask.bookId,
-            source_url: nextTask.coverUrl,
-            error,
-          });
-          markCoverStatus(nextTask.bookId, "failed");
-        })
-        .finally(() => {
-          pendingCoverBookIdsRef.current.delete(nextTask.bookId);
-          logImageEvent("cover:queue_finalized", {
-            book_id: nextTask.bookId,
-            pending_count: pendingCoverBookIdsRef.current.size,
-            queued_count: coverQueueRef.current.length,
-          });
-          void pumpCoverQueue();
-        });
-    }
-  };
-
   useEffect(() => {
     logImageEvent("app:mount", getImageDebugPageContext());
     const cachedMetadata = loadShelfMetadataSync();
@@ -321,191 +204,10 @@ const App = () => {
   }, [libraryBooks]);
 
   useEffect(() => {
-    if (libraryBooks.length === 0) {
-      return;
-    }
-
-    const visibleSet = new Set(
-      visibleBookIds.length > 0
-        ? visibleBookIds
-        : libraryBooks.slice(0, INITIAL_VISIBLE_BOOK_COUNT).map((entry) => entry.book_id),
-    );
-    logImageEvent("shelf:visible_set_computed", {
-      visible_book_ids: Array.from(visibleSet),
-      library_count: libraryBooks.length,
-    });
-
-    const visibleBooks = [];
-    const nearViewportBooks = [];
-    const visibleIndexes = [];
-
-    libraryBooks.forEach((bookEntry, index) => {
-      if (visibleSet.has(bookEntry.book_id)) {
-        visibleBooks.push(bookEntry);
-        visibleIndexes.push(index);
-        return;
-      }
-    });
-
-    const nearestVisibleIndex =
-      visibleIndexes.length > 0 ? Math.min(...visibleIndexes) : 0;
-    const furthestVisibleIndex =
-      visibleIndexes.length > 0 ? Math.max(...visibleIndexes) : INITIAL_VISIBLE_BOOK_COUNT - 1;
-
-    libraryBooks.forEach((bookEntry, index) => {
-      if (visibleSet.has(bookEntry.book_id)) {
-        return;
-      }
-
-      if (
-        index >= Math.max(0, nearestVisibleIndex - 4) &&
-        index <= Math.min(libraryBooks.length - 1, furthestVisibleIndex + 4)
-      ) {
-        nearViewportBooks.push(bookEntry);
-      }
-    });
-
-    const hydrateAndQueueCovers = async () => {
-      logImageEvent("cover:hydrate_start", {
-        visible_book_ids: visibleBooks.map((bookEntry) => bookEntry.book_id),
-        near_viewport_book_ids: nearViewportBooks.map((bookEntry) => bookEntry.book_id),
-      });
-      await Promise.all(
-        visibleBooks.map(async (bookEntry) => {
-          if (!bookEntry?.book_id || !bookEntry.cover_url) {
-            return;
-          }
-
-          if (coverStateByBookIdRef.current[bookEntry.book_id]?.status === "cached") {
-            logImageEvent("cover:hydrate_skip_cached", {
-              book_id: bookEntry.book_id,
-            });
-            return;
-          }
-
-          try {
-            const cachedCoverUrl = await getCachedShelfCover(bookEntry.book_id, bookEntry.cover_url);
-            if (cachedCoverUrl) {
-              logImageEvent("cover:hydrate_cache_hit", {
-                book_id: bookEntry.book_id,
-                source_url: bookEntry.cover_url,
-                render_cover_url: cachedCoverUrl,
-              });
-              updateCoverState({
-                bookId: bookEntry.book_id,
-                status: "cached",
-                sourceUrl: cachedCoverUrl,
-              });
-              return;
-            }
-
-            logImageEvent("cover:hydrate_cache_miss", {
-              book_id: bookEntry.book_id,
-              source_url: bookEntry.cover_url,
-            });
-            markCoverStatus(bookEntry.book_id, "uncached");
-          } catch (error) {
-            console.warn(`Failed to hydrate cached cover for ${bookEntry.book_id}:`, error);
-            logImageEvent("cover:hydrate_failed", {
-              book_id: bookEntry.book_id,
-              source_url: bookEntry.cover_url,
-              error,
-            });
-            markCoverStatus(bookEntry.book_id, "failed");
-          }
-        }),
-      );
-
-      const candidates = [];
-      for (const bookEntry of [...visibleBooks, ...nearViewportBooks]) {
-        if (!bookEntry?.book_id || !bookEntry.cover_url) {
-          continue;
-        }
-
-        const existingState = coverStateByBookIdRef.current[bookEntry.book_id];
-        if (existingState?.status === "cached" || existingState?.status === "pending") {
-          continue;
-        }
-
-        if (queuedCoverBookIdsRef.current.has(bookEntry.book_id)) {
-          continue;
-        }
-
-        const cached = await hasCachedShelfCover(bookEntry.book_id, bookEntry.cover_url);
-        if (cached) {
-          logImageEvent("cover:queue_skip_has_cached", {
-            book_id: bookEntry.book_id,
-            source_url: bookEntry.cover_url,
-          });
-          continue;
-        }
-
-        queuedCoverBookIdsRef.current.add(bookEntry.book_id);
-        candidates.push({
-          bookId: bookEntry.book_id,
-          coverUrl: bookEntry.cover_url,
-        });
-      }
-
-      if (candidates.length === 0) {
-        logImageEvent("cover:queue_noop", {});
-        return;
-      }
-
-      coverQueueRef.current = [...candidates, ...coverQueueRef.current];
-      logImageEvent("cover:queue_enqueued", {
-        candidates: candidates.map((candidate) => ({
-          book_id: candidate.bookId,
-          source_url: candidate.coverUrl,
-        })),
-        queued_count: coverQueueRef.current.length,
-      });
-      void pumpCoverQueue();
-    };
-
-    void hydrateAndQueueCovers();
-    // The queue runner is ref-driven and should not retrigger this effect.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [libraryBooks, visibleBookIds]);
-
-  const releaseAllCachedObjectUrls = () => {
-    releaseObjectUrls(Object.values(cachedCoverUrlsRef.current).filter(Boolean));
-    releaseObjectUrls(cachedBookObjectUrlsRef.current);
-  };
-
-  useEffect(() => {
     return () => {
-      releaseAllCachedObjectUrls();
+      releaseObjectUrls(cachedBookObjectUrlsRef.current);
     };
   }, []);
-
-  useEffect(() => {
-    if (typeof URL?.revokeObjectURL !== "function") {
-      previousCoverUrlsRef.current = Object.fromEntries(
-        Object.entries(coverStateByBookId).map(([bookId, state]) => [bookId, state?.url ?? null]),
-      );
-      return;
-    }
-
-    const previousUrls = previousCoverUrlsRef.current;
-    const nextUrls = Object.fromEntries(
-      Object.entries(coverStateByBookId).map(([bookId, state]) => [bookId, state?.url ?? null]),
-    );
-    const activeUrls = new Set(Object.values(nextUrls).filter(Boolean));
-
-    Object.values(previousUrls).forEach((url) => {
-      if (typeof url === "string" && url.startsWith("blob:") && !activeUrls.has(url)) {
-        console.debug(`[App] Revoking stale shelf cover object URL: ${url}`);
-        logImageEvent("cover:object_url_revoked", {
-          object_url: url,
-          reason: "stale_shelf_cover",
-        });
-        URL.revokeObjectURL(url);
-      }
-    });
-
-    previousCoverUrlsRef.current = nextUrls;
-  }, [coverStateByBookId]);
 
   useEffect(() => {
     if (typeof URL?.revokeObjectURL !== "function") {
@@ -532,20 +234,6 @@ const App = () => {
     previousBookObjectUrlsRef.current = nextUrls;
     cachedBookObjectUrlsRef.current = nextUrls;
   }, [book]);
-
-  const hydratedLibraryBooks = useMemo(
-    () =>
-      libraryBooks.map((bookEntry) => {
-        const coverState = coverStateByBookId[bookEntry.book_id];
-
-        return {
-          ...bookEntry,
-          render_cover_url: coverState?.url ?? null,
-          cover_cache_status: coverState?.status ?? (bookEntry.cover_url ? "uncached" : "missing"),
-        };
-      }),
-    [libraryBooks, coverStateByBookId],
-  );
 
   const openBook = (nextBook) => {
     setBook(nextBook);
@@ -620,10 +308,16 @@ const App = () => {
       try {
         const cachedBook = await getCachedFullBook(bookId);
         if (cachedBook) {
+          logImageEvent("full_book:cache_hit", {
+            book_id: bookId,
+          });
           openBook(cachedBook);
           return;
         }
 
+        logImageEvent("full_book:cache_miss", {
+          book_id: bookId,
+        });
         const completeBookData = await fetchAndBuildFullBook(bookId);
         openBook(completeBookData);
         upsertBookInLibrary(completeBookData);
@@ -633,6 +327,10 @@ const App = () => {
           `App.js::handleSelectBook(): Failed to get book ID ${bookId} with error`,
           error,
         );
+        logImageEvent("full_book:open_error", {
+          book_id: bookId,
+          error,
+        });
         setBook(null);
         alert("Error fetching the book. Please try again.");
       } finally {
@@ -662,7 +360,7 @@ const App = () => {
         loading={loading}
       />
       <BookList
-        books={hydratedLibraryBooks}
+        books={libraryBooks}
         loading={libraryLoading && libraryBooks.length === 0}
         error={libraryError && libraryBooks.length === 0}
         onRetry={() => fetchLibraryBooks({ force: true })}
@@ -680,7 +378,7 @@ const App = () => {
   );
 };
 
-  const styles = {
+const styles = {
   container: {
     minHeight: "100vh",
     padding: "32px 20px 48px",

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -2,11 +2,8 @@ import { act } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import App from "./App";
 
-const mockCacheShelfCover = jest.fn();
 const mockEnforceCacheBudget = jest.fn();
 const mockGetCachedFullBook = jest.fn();
-const mockGetCachedShelfCover = jest.fn();
-const mockHasCachedShelfCover = jest.fn();
 const mockLoadShelfMetadataSync = jest.fn();
 const mockSaveFullBookPackage = jest.fn();
 const mockSaveShelfMetadata = jest.fn();
@@ -16,11 +13,8 @@ jest.mock("./config", () => ({
 }));
 
 jest.mock("./cache/libraryCache", () => ({
-  cacheShelfCover: (...args) => mockCacheShelfCover(...args),
   enforceCacheBudget: (...args) => mockEnforceCacheBudget(...args),
   getCachedFullBook: (...args) => mockGetCachedFullBook(...args),
-  getCachedShelfCover: (...args) => mockGetCachedShelfCover(...args),
-  hasCachedShelfCover: (...args) => mockHasCachedShelfCover(...args),
   loadShelfMetadataSync: (...args) => mockLoadShelfMetadataSync(...args),
   saveFullBookPackage: (...args) => mockSaveFullBookPackage(...args),
   saveShelfMetadata: (...args) => mockSaveShelfMetadata(...args),
@@ -46,11 +40,8 @@ beforeEach(() => {
   window.localStorage.clear();
   global.URL.createObjectURL = jest.fn((value) => `blob:${String(value)}`);
   global.URL.revokeObjectURL = jest.fn();
-  mockCacheShelfCover.mockResolvedValue(null);
   mockEnforceCacheBudget.mockResolvedValue(undefined);
   mockGetCachedFullBook.mockResolvedValue(null);
-  mockGetCachedShelfCover.mockResolvedValue(null);
-  mockHasCachedShelfCover.mockResolvedValue(false);
   mockLoadShelfMetadataSync.mockImplementation(() => {
     const raw = window.localStorage.getItem("kwento_shelf_metadata_v1");
     return raw ? JSON.parse(raw) : null;
@@ -282,4 +273,25 @@ test("revokes cached book object URLs when the modal closes, not when it opens",
     expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:book-2-cover");
     expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:book-2-page-1");
   });
+});
+
+test("renders shelf covers from the remote cover_url", async () => {
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => [
+      {
+        book_id: "book-remote-cover",
+        book_title: "Remote Cover Book",
+        cover_url: "https://example.com/remote-cover.png",
+      },
+    ],
+  });
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  const image = await screen.findByRole("img", { name: /cover for remote cover book/i });
+  expect(image).toHaveAttribute("src", "https://example.com/remote-cover.png");
+  expect(global.URL.createObjectURL).not.toHaveBeenCalled();
 });

--- a/frontend/src/cache/libraryCache.js
+++ b/frontend/src/cache/libraryCache.js
@@ -1,29 +1,33 @@
 import { logImageEvent } from "../debug/imageDebug";
 
-const CACHE_VERSION = 1;
-const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const METADATA_CACHE_VERSION = 1;
+const FULL_BOOK_SCHEMA_VERSION = 2;
+const METADATA_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const FULL_BOOK_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+const FULL_BOOK_MAX_BYTES = 100 * 1024 * 1024;
 const DB_NAME = "kwento-cache";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const ASSETS_STORE = "assets";
 const BOOKS_STORE = "books";
 const METADATA_KEY = "kwento_shelf_metadata_v1";
-
-const CACHE_CLASS_SHELF_COVER = "shelf-cover";
 const CACHE_CLASS_FULL_BOOK = "full-book";
+const CACHE_CLASS_SHELF_COVER = "shelf-cover";
 
 let dbPromise = null;
+let maintenancePromise = null;
+let maintenanceComplete = false;
 
 const hasLocalStorage = () => typeof window !== "undefined" && window.localStorage;
 const hasIndexedDb = () => typeof window !== "undefined" && window.indexedDB;
 
 const now = () => Date.now();
 
-const withExpiry = (value = {}) => {
+const withExpiry = (value = {}, ttlMs) => {
   const updatedAt = value.updatedAt ?? now();
   return {
     ...value,
     updatedAt,
-    expiresAt: value.expiresAt ?? updatedAt + TTL_MS,
+    expiresAt: value.expiresAt ?? updatedAt + ttlMs,
   };
 };
 
@@ -55,6 +59,8 @@ const writeLocalStorageJson = (key, value) => {
 
 const resetDatabasePromise = () => {
   dbPromise = null;
+  maintenancePromise = null;
+  maintenanceComplete = false;
 };
 
 const isRecoverableDatabaseError = (error) => {
@@ -222,7 +228,127 @@ const deleteRecord = (storeName, key) =>
 const getAllRecords = (storeName) =>
   runTransaction(storeName, "readonly", (store) => store.getAll());
 
-const safeFetchBlob = async (url) => {
+const fullBookKey = (bookId) => `book:${bookId}`;
+
+const isExpired = (entry) => Boolean(entry?.expiresAt && entry.expiresAt < now());
+
+const deleteEntries = async (entries) => {
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (entry.storeName && entry.id) {
+        await deleteRecord(entry.storeName, entry.id);
+      }
+    }),
+  );
+};
+
+const estimateRecordSize = (record) => {
+  if (!record) {
+    return 0;
+  }
+
+  if (record.byteLength) {
+    return record.byteLength;
+  }
+
+  if (record.arrayBuffer instanceof ArrayBuffer) {
+    return record.arrayBuffer.byteLength;
+  }
+
+  try {
+    return new Blob([JSON.stringify(record)]).size;
+  } catch (error) {
+    return 0;
+  }
+};
+
+const isLegacyAssetRecord = (entry) => {
+  if (!entry) {
+    return false;
+  }
+
+  if (entry.cacheClass === CACHE_CLASS_SHELF_COVER) {
+    return true;
+  }
+
+  if (entry.cacheClass !== CACHE_CLASS_FULL_BOOK) {
+    return false;
+  }
+
+  return (
+    entry.schemaVersion !== FULL_BOOK_SCHEMA_VERSION ||
+    entry.blob != null ||
+    !(entry.arrayBuffer instanceof ArrayBuffer)
+  );
+};
+
+const isLegacyBookRecord = (entry) =>
+  entry?.cacheClass === CACHE_CLASS_FULL_BOOK && entry.schemaVersion !== FULL_BOOK_SCHEMA_VERSION;
+
+const ensureCacheMaintenance = async () => {
+  if (maintenanceComplete) {
+    return;
+  }
+
+  if (maintenancePromise) {
+    return maintenancePromise;
+  }
+
+  maintenancePromise = (async () => {
+    const [assetRecords, bookRecords] = await Promise.all([
+      getAllRecords(ASSETS_STORE),
+      getAllRecords(BOOKS_STORE),
+    ]);
+
+    const assets = assetRecords ?? [];
+    const books = bookRecords ?? [];
+    const removals = [];
+
+    assets.forEach((entry) => {
+      if (isLegacyAssetRecord(entry)) {
+        removals.push({
+          storeName: ASSETS_STORE,
+          id: entry.id,
+        });
+      }
+    });
+
+    books.forEach((entry) => {
+      if (isLegacyBookRecord(entry)) {
+        removals.push({
+          storeName: BOOKS_STORE,
+          id: entry.id,
+        });
+
+        (entry.assets ?? []).forEach((asset) => {
+          if (asset?.key) {
+            removals.push({
+              storeName: ASSETS_STORE,
+              id: asset.key,
+            });
+          }
+        });
+      }
+    });
+
+    if (removals.length > 0) {
+      logImageEvent("cache:legacy_cleanup", {
+        removal_count: removals.length,
+      });
+      await deleteEntries(removals);
+    }
+
+    maintenanceComplete = true;
+  })();
+
+  try {
+    await maintenancePromise;
+  } finally {
+    maintenancePromise = null;
+  }
+};
+
+const safeFetchAsset = async (url) => {
   const startedAt = now();
   const response = await fetch(url);
   if (!response.ok) {
@@ -234,23 +360,23 @@ const safeFetchBlob = async (url) => {
     throw new Error(`Failed to fetch asset. status=${response.status}`);
   }
 
-  const blob = await response.blob();
+  const arrayBuffer = await response.arrayBuffer();
+  const contentType = response.headers?.get?.("content-type") || null;
   logImageEvent("cache:fetch_success", {
     source_url: url,
     status: response.status,
     duration_ms: now() - startedAt,
-    blob_size: blob.size,
-    content_type: blob.type || response.headers?.get?.("content-type") || null,
+    byte_length: arrayBuffer.byteLength,
+    content_type: contentType,
   });
-  return blob;
+
+  return {
+    arrayBuffer,
+    contentType,
+    byteLength: arrayBuffer.byteLength,
+  };
 };
 
-const shelfCoverKey = (bookId) => `cover:${bookId}`;
-const fullBookKey = (bookId) => `book:${bookId}`;
-
-const isExpired = (entry) => Boolean(entry?.expiresAt && entry.expiresAt < now());
-
-const approximateBlobSize = (blob) => blob?.size ?? 0;
 const toObjectUrl = (blob, fallbackUrl = null, debugContext = {}) => {
   if (typeof URL?.createObjectURL !== "function") {
     logImageEvent("cache:object_url_fallback", {
@@ -271,25 +397,13 @@ const toObjectUrl = (blob, fallbackUrl = null, debugContext = {}) => {
   return objectUrl;
 };
 
-const estimateRecordSize = (record) => {
-  if (!record) {
-    return 0;
-  }
-
-  if (record.blob) {
-    return approximateBlobSize(record.blob);
-  }
-
-  try {
-    return new Blob([JSON.stringify(record)]).size;
-  } catch (error) {
-    return 0;
-  }
-};
-
 export const loadShelfMetadataSync = () => {
   const entry = readLocalStorageJson(METADATA_KEY);
-  if (!entry || entry.version !== CACHE_VERSION || !Array.isArray(entry.books)) {
+  if (!entry || !Array.isArray(entry.books)) {
+    return null;
+  }
+
+  if (entry.version !== METADATA_CACHE_VERSION || isExpired(entry)) {
     return null;
   }
 
@@ -297,138 +411,16 @@ export const loadShelfMetadataSync = () => {
 };
 
 export const saveShelfMetadata = async (books) => {
-  const entry = withExpiry({
-    version: CACHE_VERSION,
-    books: Array.isArray(books) ? books : [],
-  });
+  const entry = withExpiry(
+    {
+      version: METADATA_CACHE_VERSION,
+      books: Array.isArray(books) ? books : [],
+    },
+    METADATA_TTL_MS,
+  );
 
   writeLocalStorageJson(METADATA_KEY, entry);
   return entry;
-};
-
-export const getCachedShelfCover = async (bookId, sourceUrl) => {
-  const entry = await getRecord(ASSETS_STORE, shelfCoverKey(bookId));
-  if (!entry || !entry.blob || isExpired(entry)) {
-    logImageEvent("cover:get_cached_miss", {
-      book_id: bookId,
-      source_url: sourceUrl,
-      cache_entry_present: Boolean(entry),
-      expired: isExpired(entry),
-    });
-    console.debug(`[libraryCache] shelf cover miss for ${bookId}`);
-    return null;
-  }
-
-  if (sourceUrl && entry.sourceUrl !== sourceUrl) {
-    entry.sourceUrl = sourceUrl;
-  }
-
-  entry.lastUsedAt = now();
-  await putRecord(ASSETS_STORE, entry);
-  logImageEvent("cover:get_cached_hit", {
-    book_id: bookId,
-    source_url: sourceUrl,
-    cached_source_url: entry.sourceUrl ?? null,
-    blob_size: approximateBlobSize(entry.blob),
-  });
-  console.debug(
-    `[libraryCache] shelf cover hit for ${bookId} via cached blob (${sourceUrl ? "remote-source-observed" : "no-source"})`,
-  );
-  return toObjectUrl(entry.blob, entry.sourceUrl ?? sourceUrl, {
-    book_id: bookId,
-    source_url: entry.sourceUrl ?? sourceUrl,
-    origin: "getCachedShelfCover",
-  });
-};
-
-export const hasCachedShelfCover = async (bookId, sourceUrl) => {
-  const entry = await getRecord(ASSETS_STORE, shelfCoverKey(bookId));
-  if (!entry || !entry.blob || isExpired(entry)) {
-    logImageEvent("cover:has_cached_miss", {
-      book_id: bookId,
-      source_url: sourceUrl,
-      cache_entry_present: Boolean(entry),
-      expired: isExpired(entry),
-    });
-    console.debug(`[libraryCache] hasCachedShelfCover miss for ${bookId}`);
-    return false;
-  }
-
-  if (sourceUrl && entry.sourceUrl !== sourceUrl) {
-    entry.sourceUrl = sourceUrl;
-    await putRecord(ASSETS_STORE, entry);
-  }
-
-  logImageEvent("cover:has_cached_hit", {
-    book_id: bookId,
-    source_url: sourceUrl,
-    cached_source_url: entry.sourceUrl ?? null,
-    blob_size: approximateBlobSize(entry.blob),
-  });
-  console.debug(`[libraryCache] hasCachedShelfCover hit for ${bookId}`);
-  return true;
-};
-
-export const cacheShelfCover = async ({ bookId, sourceUrl }) => {
-  if (!bookId || !sourceUrl) {
-    logImageEvent("cover:cache_skip", {
-      book_id: bookId,
-      source_url: sourceUrl,
-    });
-    return null;
-  }
-
-  const db = await openDatabase();
-  if (!db) {
-    logImageEvent("cover:cache_bypass", {
-      book_id: bookId,
-      source_url: sourceUrl,
-      reason: "no_indexeddb",
-    });
-    return sourceUrl;
-  }
-
-  const existing = await getRecord(ASSETS_STORE, shelfCoverKey(bookId));
-  if (existing?.blob && !isExpired(existing)) {
-    existing.sourceUrl = sourceUrl;
-    existing.lastUsedAt = now();
-    await putRecord(ASSETS_STORE, existing);
-    logImageEvent("cover:cache_hit_reuse", {
-      book_id: bookId,
-      source_url: sourceUrl,
-      blob_size: approximateBlobSize(existing.blob),
-    });
-    console.debug(`[libraryCache] shelf cover cache hit for ${bookId}; reusing cached blob`);
-    return toObjectUrl(existing.blob, existing.sourceUrl, {
-      book_id: bookId,
-      source_url: existing.sourceUrl,
-      origin: "cacheShelfCover:existing",
-    });
-  }
-
-  const blob = await safeFetchBlob(sourceUrl);
-  const entry = withExpiry({
-    id: shelfCoverKey(bookId),
-    bookId,
-    sourceUrl,
-    blob,
-    cacheClass: CACHE_CLASS_SHELF_COVER,
-    lastUsedAt: now(),
-  });
-
-  await putRecord(ASSETS_STORE, entry);
-  logImageEvent("cover:cache_store", {
-    book_id: bookId,
-    source_url: sourceUrl,
-    blob_size: approximateBlobSize(blob),
-    expires_at: entry.expiresAt,
-  });
-  console.debug(`[libraryCache] shelf cover cache miss for ${bookId}; fetched remote asset`);
-  return toObjectUrl(blob, sourceUrl, {
-    book_id: bookId,
-    source_url: sourceUrl,
-    origin: "cacheShelfCover:fetched",
-  });
 };
 
 const buildFullBookAssetEntries = async (book) => {
@@ -459,17 +451,23 @@ const buildFullBookAssetEntries = async (book) => {
 
   const assets = await Promise.all(
     assetDescriptors.map(async (asset) => {
-      const blob = await safeFetchBlob(asset.sourceUrl);
-      const entry = withExpiry({
-        id: asset.key,
-        bookId: book.book_id,
-        page: asset.page,
-        sourceUrl: asset.sourceUrl,
-        blob,
-        cacheClass: CACHE_CLASS_FULL_BOOK,
-        assetType: asset.type,
-        lastUsedAt: now(),
-      });
+      const { arrayBuffer, contentType, byteLength } = await safeFetchAsset(asset.sourceUrl);
+      const entry = withExpiry(
+        {
+          id: asset.key,
+          schemaVersion: FULL_BOOK_SCHEMA_VERSION,
+          bookId: book.book_id,
+          page: asset.page,
+          sourceUrl: asset.sourceUrl,
+          arrayBuffer,
+          byteLength,
+          contentType,
+          cacheClass: CACHE_CLASS_FULL_BOOK,
+          assetType: asset.type,
+          lastUsedAt: now(),
+        },
+        FULL_BOOK_TTL_MS,
+      );
 
       await putRecord(ASSETS_STORE, entry);
       return {
@@ -484,6 +482,27 @@ const buildFullBookAssetEntries = async (book) => {
   return assets;
 };
 
+const deleteFullBookPackage = async (packageRecord) => {
+  if (!packageRecord) {
+    return;
+  }
+
+  const removals = [
+    {
+      storeName: BOOKS_STORE,
+      id: packageRecord.id,
+    },
+    ...(packageRecord.assets ?? [])
+      .filter((asset) => asset?.key)
+      .map((asset) => ({
+        storeName: ASSETS_STORE,
+        id: asset.key,
+      })),
+  ];
+
+  await deleteEntries(removals);
+};
+
 export const saveFullBookPackage = async (book) => {
   if (!book?.book_id) {
     return null;
@@ -494,18 +513,29 @@ export const saveFullBookPackage = async (book) => {
     return null;
   }
 
+  await ensureCacheMaintenance();
+
+  const existingPackage = await getRecord(BOOKS_STORE, fullBookKey(book.book_id));
+  if (existingPackage) {
+    await deleteFullBookPackage(existingPackage);
+  }
+
   const assets = await buildFullBookAssetEntries(book);
-  const packageRecord = withExpiry({
-    id: fullBookKey(book.book_id),
-    bookId: book.book_id,
-    cacheClass: CACHE_CLASS_FULL_BOOK,
-    lastUsedAt: now(),
-    package: {
-      ...book,
-      cachedAt: now(),
+  const packageRecord = withExpiry(
+    {
+      id: fullBookKey(book.book_id),
+      schemaVersion: FULL_BOOK_SCHEMA_VERSION,
+      bookId: book.book_id,
+      cacheClass: CACHE_CLASS_FULL_BOOK,
+      lastUsedAt: now(),
+      package: {
+        ...book,
+        cachedAt: now(),
+      },
+      assets,
     },
-    assets,
-  });
+    FULL_BOOK_TTL_MS,
+  );
 
   await putRecord(BOOKS_STORE, packageRecord);
   return packageRecord;
@@ -517,28 +547,67 @@ export const getCachedFullBook = async (bookId) => {
     return null;
   }
 
+  await ensureCacheMaintenance();
+
   const packageRecord = await getRecord(BOOKS_STORE, fullBookKey(bookId));
-  if (!packageRecord || !packageRecord.package || isExpired(packageRecord)) {
+  if (!packageRecord || !packageRecord.package) {
+    return null;
+  }
+
+  if (packageRecord.schemaVersion !== FULL_BOOK_SCHEMA_VERSION || isExpired(packageRecord)) {
+    await deleteFullBookPackage(packageRecord);
+    logImageEvent("full_book:cache_invalidated", {
+      book_id: bookId,
+      reason: isExpired(packageRecord) ? "expired" : "schema_mismatch",
+    });
     return null;
   }
 
   const assets = await Promise.all(
     (packageRecord.assets ?? []).map(async (asset) => {
       const entry = await getRecord(ASSETS_STORE, asset.key);
-      if (!entry?.blob || isExpired(entry)) {
+      if (
+        !entry ||
+        entry.schemaVersion !== FULL_BOOK_SCHEMA_VERSION ||
+        isExpired(entry) ||
+        !(entry.arrayBuffer instanceof ArrayBuffer)
+      ) {
         return null;
       }
 
       entry.lastUsedAt = now();
       await putRecord(ASSETS_STORE, entry);
+
+      const blob = new Blob([entry.arrayBuffer], {
+        type: entry.contentType || "application/octet-stream",
+      });
+      const objectUrl = toObjectUrl(blob, entry.sourceUrl, {
+        book_id: bookId,
+        source_url: entry.sourceUrl,
+        origin: "getCachedFullBook",
+      });
+      logImageEvent("full_book:asset_reconstructed", {
+        book_id: bookId,
+        asset_key: asset.key,
+        asset_type: asset.type,
+        page: asset.page,
+        byte_length: entry.byteLength ?? entry.arrayBuffer.byteLength,
+        content_type: entry.contentType || null,
+      });
+
       return {
         ...asset,
-        objectUrl: toObjectUrl(entry.blob, entry.sourceUrl),
+        objectUrl,
       };
     }),
   );
 
   if (assets.some((asset) => asset === null)) {
+    await deleteFullBookPackage(packageRecord);
+    logImageEvent("full_book:cache_invalidated", {
+      book_id: bookId,
+      reason: "missing_asset",
+    });
     return null;
   }
 
@@ -567,17 +636,9 @@ export const getCachedFullBook = async (bookId) => {
   };
 };
 
-const deleteEntries = async (entries) => {
-  await Promise.all(
-    entries.map(async (entry) => {
-      if (entry.storeName && entry.id) {
-        await deleteRecord(entry.storeName, entry.id);
-      }
-    }),
-  );
-};
+export const enforceCacheBudget = async ({ maxBytes = FULL_BOOK_MAX_BYTES } = {}) => {
+  await ensureCacheMaintenance();
 
-export const enforceCacheBudget = async ({ maxBytes = 500 * 1024 * 1024 } = {}) => {
   const [assetRecords, bookRecords] = await Promise.all([
     getAllRecords(ASSETS_STORE),
     getAllRecords(BOOKS_STORE),
@@ -585,55 +646,66 @@ export const enforceCacheBudget = async ({ maxBytes = 500 * 1024 * 1024 } = {}) 
 
   const assets = assetRecords ?? [];
   const books = bookRecords ?? [];
-  const metadata = loadShelfMetadataSync();
-  const metadataSize = metadata ? estimateRecordSize(metadata) : 0;
-
-  const candidates = [
-    ...books.map((entry) => ({ ...entry, storeName: BOOKS_STORE, size: estimateRecordSize(entry) })),
-    ...assets.map((entry) => ({ ...entry, storeName: ASSETS_STORE, size: estimateRecordSize(entry) })),
-  ];
-
-  let totalSize = metadataSize + candidates.reduce((sum, entry) => sum + entry.size, 0);
-  if (totalSize <= maxBytes) {
-    return;
-  }
-
-  const evictionPriority = (entry) => {
-    if (entry.cacheClass === CACHE_CLASS_FULL_BOOK) {
-      return 0;
-    }
-
-    if (entry.cacheClass === CACHE_CLASS_SHELF_COVER) {
-      return 1;
-    }
-
-    return 2;
-  };
-
-  const evictableEntries = candidates.sort((left, right) => {
-    const classDelta = evictionPriority(left) - evictionPriority(right);
-    if (classDelta !== 0) {
-      return classDelta;
-    }
-
-    const leftExpired = isExpired(left) ? 0 : 1;
-    const rightExpired = isExpired(right) ? 0 : 1;
-    if (leftExpired !== rightExpired) {
-      return leftExpired - rightExpired;
-    }
-
-    return (left.lastUsedAt ?? left.updatedAt ?? 0) - (right.lastUsedAt ?? right.updatedAt ?? 0);
-  });
+  const assetEntriesById = new Map(assets.map((entry) => [entry.id, entry]));
+  const packageRecords = books.filter(
+    (entry) =>
+      entry?.cacheClass === CACHE_CLASS_FULL_BOOK && entry.schemaVersion === FULL_BOOK_SCHEMA_VERSION,
+  );
 
   const removals = [];
-  for (const entry of evictableEntries) {
-    if (totalSize <= maxBytes) {
+  let totalSize = 0;
+  const packageSummaries = packageRecords.map((entry) => {
+    const packageSize = estimateRecordSize(entry);
+    const assetSize = (entry.assets ?? []).reduce((sum, asset) => {
+      const assetEntry = assetEntriesById.get(asset.key);
+      return sum + estimateRecordSize(assetEntry);
+    }, 0);
+    const size = packageSize + assetSize;
+
+    totalSize += size;
+    return {
+      entry,
+      size,
+      expired: isExpired(entry),
+      lastUsedAt: entry.lastUsedAt ?? entry.updatedAt ?? 0,
+    };
+  });
+
+  packageSummaries.forEach((summary) => {
+    if (summary.expired) {
+      removals.push(summary.entry);
+    }
+  });
+
+  if (removals.length > 0) {
+    await Promise.all(removals.map((entry) => deleteFullBookPackage(entry)));
+    logImageEvent("full_book:budget_cleanup", {
+      expired_package_count: removals.length,
+      total_size_before_eviction: totalSize,
+    });
+  }
+
+  const activePackages = packageSummaries
+    .filter((summary) => !summary.expired)
+    .sort((left, right) => left.lastUsedAt - right.lastUsedAt);
+
+  let activeSize = activePackages.reduce((sum, summary) => sum + summary.size, 0);
+  const evictedBookIds = [];
+  for (const summary of activePackages) {
+    if (activeSize <= maxBytes) {
       break;
     }
 
-    removals.push(entry);
-    totalSize -= entry.size;
+    await deleteFullBookPackage(summary.entry);
+    activeSize -= summary.size;
+    evictedBookIds.push(summary.entry.bookId);
   }
 
-  await deleteEntries(removals);
+  if (evictedBookIds.length > 0) {
+    logImageEvent("full_book:budget_eviction", {
+      evicted_book_ids: evictedBookIds,
+      max_bytes: maxBytes,
+      total_size_after_eviction: activeSize,
+    });
+  }
 };

--- a/frontend/src/cache/libraryCache.test.js
+++ b/frontend/src/cache/libraryCache.test.js
@@ -74,7 +74,9 @@ const createFakeIndexedDb = () => {
   };
 };
 
-describe("libraryCache shelf cover identity", () => {
+const makeArrayBuffer = (value) => Uint8Array.from(value.split("").map((char) => char.charCodeAt(0))).buffer;
+
+describe("libraryCache full-book persistence", () => {
   let libraryCache;
   let createObjectUrlCount;
 
@@ -89,49 +91,104 @@ describe("libraryCache shelf cover identity", () => {
     });
     global.URL.revokeObjectURL = jest.fn();
     window.indexedDB = createFakeIndexedDb();
+    window.localStorage.clear();
 
     libraryCache = require("./libraryCache");
   });
 
-  test("reuses a cached shelf cover even when the presigned URL changes", async () => {
-    const blob = new Blob(["cover-bytes"]);
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      blob: async () => blob,
+  test("saves and rehydrates a full book package using ArrayBuffer asset records", async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => makeArrayBuffer("cover-bytes"),
+        headers: { get: () => "image/png" },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => makeArrayBuffer("page-bytes"),
+        headers: { get: () => "image/png" },
+      });
+
+    await libraryCache.saveFullBookPackage({
+      book_id: "book-1",
+      book_title: "Cached Book",
+      cover_url: "https://example.com/cover.png",
+      images: [
+        {
+          page: 1,
+          url: "https://example.com/page-1.png",
+        },
+      ],
+      pages: [
+        {
+          page_number: 1,
+          content: {
+            text_content_of_this_page: "Page one",
+          },
+        },
+      ],
     });
 
-    const firstObjectUrl = await libraryCache.cacheShelfCover({
-      bookId: "book-1",
-      sourceUrl: "https://example.com/cover.png?sig=one",
-    });
-    const secondObjectUrl = await libraryCache.cacheShelfCover({
-      bookId: "book-1",
-      sourceUrl: "https://example.com/cover.png?sig=two",
-    });
+    const cachedBook = await libraryCache.getCachedFullBook("book-1");
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(firstObjectUrl).toBe("blob:generated-1");
-    expect(secondObjectUrl).toBe("blob:generated-2");
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(cachedBook.cover_url).toBe("blob:generated-1");
+    expect(cachedBook.images[0].url).toBe("blob:generated-2");
+    expect(cachedBook.__cachedObjectUrls).toEqual(["blob:generated-1", "blob:generated-2"]);
   });
 
-  test("treats a rotated presigned URL as a cache hit for lookup helpers", async () => {
-    const blob = new Blob(["cover-bytes"]);
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      blob: async () => blob,
+  test("keeps shelf metadata in localStorage with a 7 day freshness window", async () => {
+    const saved = await libraryCache.saveShelfMetadata([
+      {
+        book_id: "book-meta",
+        book_title: "Metadata Book",
+      },
+    ]);
+
+    expect(saved.version).toBe(1);
+    expect(saved.expiresAt - saved.updatedAt).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(libraryCache.loadShelfMetadataSync()).toEqual(saved);
+  });
+
+  test("evicts expired and least-recently-used full book packages under the budget", async () => {
+    const nowSpy = jest.spyOn(Date, "now");
+    nowSpy.mockReturnValue(1_000);
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => makeArrayBuffer("a".repeat(5_000)),
+        headers: { get: () => "image/png" },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => makeArrayBuffer("b".repeat(16)),
+        headers: { get: () => "image/png" },
+      });
+
+    await libraryCache.saveFullBookPackage({
+      book_id: "older-book",
+      book_title: "Older Book",
+      cover_url: "https://example.com/older-cover.png",
+      images: [],
+      pages: [],
     });
 
-    await libraryCache.cacheShelfCover({
-      bookId: "book-2",
-      sourceUrl: "https://example.com/cover.png?sig=one",
+    nowSpy.mockReturnValue(2_000);
+
+    await libraryCache.saveFullBookPackage({
+      book_id: "newer-book",
+      book_title: "Newer Book",
+      cover_url: "https://example.com/newer-cover.png",
+      images: [],
+      pages: [],
     });
 
-    await expect(
-      libraryCache.hasCachedShelfCover("book-2", "https://example.com/cover.png?sig=two"),
-    ).resolves.toBe(true);
+    await libraryCache.enforceCacheBudget({ maxBytes: 1_000 });
 
-    await expect(
-      libraryCache.getCachedShelfCover("book-2", "https://example.com/cover.png?sig=three"),
-    ).resolves.toBe("blob:generated-2");
+    await expect(libraryCache.getCachedFullBook("older-book")).resolves.toBeNull();
+    await expect(libraryCache.getCachedFullBook("newer-book")).resolves.not.toBeNull();
+
+    nowSpy.mockRestore();
   });
 });

--- a/frontend/src/components/BookList.js
+++ b/frontend/src/components/BookList.js
@@ -11,7 +11,7 @@ const TAB_HEIGHT = 52;
 const TAB_BAR_OVERLAP = 8;
 const ACTIVE_TAB_BRIDGE_HEIGHT = 12;
 
-const BookCoverImage = ({ bookId, coverUrl, cacheStatus, bookTitle, onSizeChange }) => {
+const BookCoverImage = ({ bookId, coverUrl, sourceKind, bookTitle, onSizeChange }) => {
   const [isVisible, setIsVisible] = useState(Boolean(coverUrl));
   const imageRef = useRef(null);
 
@@ -39,26 +39,26 @@ const BookCoverImage = ({ bookId, coverUrl, cacheStatus, bookTitle, onSizeChange
     logImageEvent("img:prop_change", {
       book_id: bookId,
       render_cover_url: coverUrl,
-      cover_cache_status: cacheStatus,
+      source_kind: sourceKind,
       is_visible: Boolean(coverUrl),
     });
-  }, [bookId, cacheStatus, coverUrl]);
+  }, [bookId, coverUrl, sourceKind]);
 
   useEffect(() => {
     logImageEvent("img:component_mount", {
       book_id: bookId,
       render_cover_url: coverUrl,
-      cover_cache_status: cacheStatus,
+      source_kind: sourceKind,
     });
 
     return () => {
       logImageEvent("img:component_unmount", {
         book_id: bookId,
         render_cover_url: coverUrl,
-        cover_cache_status: cacheStatus,
+        source_kind: sourceKind,
       });
     };
-  }, [bookId, cacheStatus, coverUrl]);
+  }, [bookId, coverUrl, sourceKind]);
 
   if (!coverUrl || !isVisible) {
     return null;
@@ -75,7 +75,7 @@ const BookCoverImage = ({ bookId, coverUrl, cacheStatus, bookTitle, onSizeChange
           logImageEvent("img:load", {
             book_id: bookId,
             render_cover_url: coverUrl,
-            cover_cache_status: cacheStatus,
+            source_kind: sourceKind,
             snapshot: buildImageSnapshot(),
           });
           onSizeChange();
@@ -84,7 +84,7 @@ const BookCoverImage = ({ bookId, coverUrl, cacheStatus, bookTitle, onSizeChange
           logImageEvent("img:error", {
             book_id: bookId,
             render_cover_url: coverUrl,
-            cover_cache_status: cacheStatus,
+            source_kind: sourceKind,
             snapshot: buildImageSnapshot(),
             page: getImageDebugPageContext(),
           });
@@ -267,8 +267,8 @@ const BookList = ({
               <div style={styles.coverSlot}>
                 <BookCoverImage
                   bookId={book.book_id}
-                  coverUrl={book.render_cover_url}
-                  cacheStatus={book.cover_cache_status}
+                  coverUrl={book.cover_url}
+                  sourceKind="remote"
                   bookTitle={book.book_title}
                   onSizeChange={handleSizeChange}
                 />

--- a/frontend/src/components/BookList.test.js
+++ b/frontend/src/components/BookList.test.js
@@ -81,7 +81,6 @@ describe("BookList", () => {
         book_id: "book-2",
         book_title: "The Cover Book",
         cover_url: "https://example.com/cover.png",
-        render_cover_url: "blob:cached-cover",
       },
     ]);
 
@@ -102,12 +101,11 @@ describe("BookList", () => {
     });
   });
 
-  test("renders title-only when no cached shelf cover is available", () => {
+  test("renders title-only when no shelf cover URL is available", () => {
     renderBookList([
       {
         book_id: "book-3",
         book_title: "Title Only",
-        cover_url: "https://example.com/remote-cover.png",
       },
     ]);
 
@@ -121,7 +119,6 @@ describe("BookList", () => {
         book_id: "book-4",
         book_title: "Broken Cover",
         cover_url: "https://example.com/broken-cover.png",
-        render_cover_url: "blob:broken-cover",
       },
     ]);
 


### PR DESCRIPTION
Shelf covers now use the browser’s standard image caching path, which should eliminate the iPhone Safari blob-related blinking and missing-image failures while keeping shelf loading fast and consistent across browsers. Offline-style caching is now limited to opened books only, with tighter retention limits so local storage stays coherent and bounded instead of mixing small shelf data with large book assets.