### PR TITLE
frontend cache freshness fix

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -27,6 +27,9 @@ const releaseObjectUrls = (urls = []) => {
 const sortBooksByTitle = (books = []) =>
   [...books].sort((left, right) => left.book_title.localeCompare(right.book_title));
 
+const areBookIdListsEqual = (left = [], right = []) =>
+  left.length === right.length && left.every((value, index) => value === right[index]);
+
 const normalizeBook = (bookData = {}) => ({
   ...bookData,
   book_id: bookData.book_id,
@@ -52,6 +55,7 @@ const App = () => {
   const cachedBookObjectUrlsRef = useRef([]);
   const previousBookObjectUrlsRef = useRef([]);
   const inFlightBookSelectionRef = useRef(new Map());
+  const visibleBookIdsRef = useRef([]);
 
   const cacheFullBookInBackground = async (completeBookData) => {
     try {
@@ -252,6 +256,16 @@ const App = () => {
     setIsModalOpen(true);
   };
 
+  const handleVisibleBooksChange = useCallback((nextVisibleBookIds) => {
+    const normalizedIds = Array.isArray(nextVisibleBookIds) ? nextVisibleBookIds : [];
+    if (areBookIdListsEqual(visibleBookIdsRef.current, normalizedIds)) {
+      return;
+    }
+
+    visibleBookIdsRef.current = normalizedIds;
+    setVisibleBookIds(normalizedIds);
+  }, []);
+
   const handleGenerateBook = async () => {
     if (!theme.trim()) {
       alert("Please enter a theme to generate a book.");
@@ -448,7 +462,7 @@ const App = () => {
         error={libraryError && libraryBooks.length === 0}
         onRetry={() => fetchLibraryBooks({ force: true })}
         onSelectBook={handleSelectBook}
-        onVisibleBooksChange={setVisibleBookIds}
+        onVisibleBooksChange={handleVisibleBooksChange}
         onToggleArchive={handleToggleArchive}
         archiveActionBookIds={archiveActionBookIds}
       />

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -138,6 +138,52 @@ test("renders cached shelf metadata before the background refresh resolves", asy
   });
 });
 
+test("suppresses stale cached shelf covers until refreshed shelf data arrives", async () => {
+  const now = Date.now();
+  mockLoadShelfMetadataSync.mockReturnValue({
+    version: 1,
+    books: [
+      {
+        book_id: "cached-book-stale-cover",
+        book_title: "Cached Shelf Book",
+        cover_url: null,
+        cover_expires_at: new Date(now - 60_000).toISOString(),
+        is_archived: false,
+      },
+    ],
+    updatedAt: now,
+    expiresAt: now + 1_000,
+  });
+
+  const booksRequest = createDeferred();
+  global.fetch.mockReturnValue(booksRequest.promise);
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  expect(screen.getByRole("button", { name: exactName("Cached Shelf Book") })).toBeInTheDocument();
+  expect(screen.queryByRole("img", { name: /cover for cached shelf book/i })).not.toBeInTheDocument();
+
+  await act(async () => {
+    booksRequest.resolve({
+      ok: true,
+      json: async () => [
+        {
+          book_id: "cached-book-stale-cover",
+          book_title: "Cached Shelf Book",
+          cover_url: "https://example.com/fresh-cover.png",
+          cover_expires_at: new Date(now + 60 * 60 * 1000).toISOString(),
+          is_archived: false,
+        },
+      ],
+    });
+  });
+
+  const image = await screen.findByRole("img", { name: /cover for cached shelf book/i });
+  expect(image).toHaveAttribute("src", "https://example.com/fresh-cover.png");
+});
+
 test("keeps cached shelf metadata visible when the background refresh fails", async () => {
   window.localStorage.setItem(
     "kwento_shelf_metadata_v1",
@@ -237,6 +283,7 @@ test("revokes cached book object URLs when the modal closes, not when it opens",
   mockGetCachedFullBook.mockResolvedValue({
     book_id: "book-2",
     book_title: "Cached Modal Book",
+    json_url: "https://example.com/stale-book-2.json",
     __cachedObjectUrls: ["blob:book-2-cover", "blob:book-2-page-1"],
     pages: [
       {
@@ -274,6 +321,7 @@ test("revokes cached book object URLs when the modal closes, not when it opens",
 
   expect(await screen.findByRole("button", { name: /close modal/i })).toBeInTheDocument();
   expect(global.URL.revokeObjectURL).not.toHaveBeenCalled();
+  expect(global.fetch).toHaveBeenCalledTimes(1);
 
   fireEvent.click(screen.getByRole("button", { name: /close modal/i }));
 

--- a/frontend/src/cache/libraryCache.js
+++ b/frontend/src/cache/libraryCache.js
@@ -4,6 +4,7 @@ const METADATA_CACHE_VERSION = 1;
 const FULL_BOOK_SCHEMA_VERSION = 2;
 const METADATA_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const FULL_BOOK_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+const SIGNED_URL_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 const FULL_BOOK_MAX_BYTES = 100 * 1024 * 1024;
 const DB_NAME = "kwento-cache";
 const DB_VERSION = 2;
@@ -232,6 +233,45 @@ const fullBookKey = (bookId) => `book:${bookId}`;
 
 const isExpired = (entry) => Boolean(entry?.expiresAt && entry.expiresAt < now());
 
+const parseTimestamp = (value) => {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (value instanceof Date) {
+    const timestamp = value.getTime();
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+export const isSignedUrlUsable = (expiresAt, { bufferMs = SIGNED_URL_EXPIRY_BUFFER_MS } = {}) => {
+  const expiresAtMs = parseTimestamp(expiresAt);
+  if (expiresAtMs == null) {
+    return true;
+  }
+
+  return expiresAtMs - bufferMs > now();
+};
+
+const sanitizeShelfBook = (book = {}) => {
+  const coverExpiresAt = book.cover_expires_at ?? book.cover?.expires_at ?? null;
+  if (!book.cover_url || isSignedUrlUsable(coverExpiresAt)) {
+    return book;
+  }
+
+  return {
+    ...book,
+    cover_url: null,
+  };
+};
+
 const deleteEntries = async (entries) => {
   await Promise.all(
     entries.map(async (entry) => {
@@ -407,7 +447,10 @@ export const loadShelfMetadataSync = () => {
     return null;
   }
 
-  return entry;
+  return {
+    ...entry,
+    books: entry.books.map((book) => sanitizeShelfBook(book)),
+  };
 };
 
 export const saveShelfMetadata = async (books) => {
@@ -449,37 +492,50 @@ const buildFullBookAssetEntries = async (book) => {
     });
   }
 
-  const assets = await Promise.all(
-    assetDescriptors.map(async (asset) => {
-      const { arrayBuffer, contentType, byteLength } = await safeFetchAsset(asset.sourceUrl);
-      const entry = withExpiry(
-        {
-          id: asset.key,
-          schemaVersion: FULL_BOOK_SCHEMA_VERSION,
-          bookId: book.book_id,
+  const persistedAssetKeys = [];
+
+  try {
+    const assets = await Promise.all(
+      assetDescriptors.map(async (asset) => {
+        const { arrayBuffer, contentType, byteLength } = await safeFetchAsset(asset.sourceUrl);
+        const entry = withExpiry(
+          {
+            id: asset.key,
+            schemaVersion: FULL_BOOK_SCHEMA_VERSION,
+            bookId: book.book_id,
+            page: asset.page,
+            sourceUrl: asset.sourceUrl,
+            arrayBuffer,
+            byteLength,
+            contentType,
+            cacheClass: CACHE_CLASS_FULL_BOOK,
+            assetType: asset.type,
+            lastUsedAt: now(),
+          },
+          FULL_BOOK_TTL_MS,
+        );
+
+        await putRecord(ASSETS_STORE, entry);
+        persistedAssetKeys.push(asset.key);
+        return {
+          key: asset.key,
+          type: asset.type,
           page: asset.page,
           sourceUrl: asset.sourceUrl,
-          arrayBuffer,
-          byteLength,
-          contentType,
-          cacheClass: CACHE_CLASS_FULL_BOOK,
-          assetType: asset.type,
-          lastUsedAt: now(),
-        },
-        FULL_BOOK_TTL_MS,
-      );
+        };
+      }),
+    );
 
-      await putRecord(ASSETS_STORE, entry);
-      return {
-        key: asset.key,
-        type: asset.type,
-        page: asset.page,
-        sourceUrl: asset.sourceUrl,
-      };
-    }),
-  );
-
-  return assets;
+    return assets;
+  } catch (error) {
+    await deleteEntries(
+      persistedAssetKeys.map((assetKey) => ({
+        storeName: ASSETS_STORE,
+        id: assetKey,
+      })),
+    );
+    throw error;
+  }
 };
 
 const deleteFullBookPackage = async (packageRecord) => {
@@ -516,11 +572,10 @@ export const saveFullBookPackage = async (book) => {
   await ensureCacheMaintenance();
 
   const existingPackage = await getRecord(BOOKS_STORE, fullBookKey(book.book_id));
+  const assets = await buildFullBookAssetEntries(book);
   if (existingPackage) {
     await deleteFullBookPackage(existingPackage);
   }
-
-  const assets = await buildFullBookAssetEntries(book);
   const packageRecord = withExpiry(
     {
       id: fullBookKey(book.book_id),
@@ -621,6 +676,7 @@ export const getCachedFullBook = async (bookId) => {
 
   return {
     ...packageRecord.package,
+    json_url: null,
     cover: packageRecord.package.cover
       ? {
           ...packageRecord.package.cover,

--- a/frontend/src/cache/libraryCache.test.js
+++ b/frontend/src/cache/libraryCache.test.js
@@ -150,6 +150,47 @@ describe("libraryCache full-book persistence", () => {
     expect(libraryCache.loadShelfMetadataSync()).toEqual(saved);
   });
 
+  test("suppresses stale cached shelf cover URLs while keeping metadata", async () => {
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(1_000_000);
+
+    await libraryCache.saveShelfMetadata([
+      {
+        book_id: "book-meta",
+        book_title: "Metadata Book",
+        cover_url: "https://example.com/stale-cover.png",
+        cover_expires_at: new Date(1_000_000 + 60_000).toISOString(),
+      },
+    ]);
+
+    expect(libraryCache.loadShelfMetadataSync()).toEqual(
+      expect.objectContaining({
+        books: [
+          expect.objectContaining({
+            book_id: "book-meta",
+            book_title: "Metadata Book",
+            cover_url: null,
+            cover_expires_at: new Date(1_000_000 + 60_000).toISOString(),
+          }),
+        ],
+      }),
+    );
+
+    nowSpy.mockRestore();
+  });
+
+  test("reports signed URLs as stale within the five minute safety buffer", () => {
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(1_000_000);
+
+    expect(libraryCache.isSignedUrlUsable(new Date(1_000_000 + 10 * 60 * 1000).toISOString())).toBe(
+      true,
+    );
+    expect(libraryCache.isSignedUrlUsable(new Date(1_000_000 + 4 * 60 * 1000).toISOString())).toBe(
+      false,
+    );
+
+    nowSpy.mockRestore();
+  });
+
   test("evicts expired and least-recently-used full book packages under the budget", async () => {
     const nowSpy = jest.spyOn(Date, "now");
     nowSpy.mockReturnValue(1_000);
@@ -190,5 +231,75 @@ describe("libraryCache full-book persistence", () => {
     await expect(libraryCache.getCachedFullBook("newer-book")).resolves.not.toBeNull();
 
     nowSpy.mockRestore();
+  });
+
+  test("preserves an existing full-book package when a replacement save fails", async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => makeArrayBuffer("cover-a"),
+        headers: { get: () => "image/png" },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => makeArrayBuffer("page-a"),
+        headers: { get: () => "image/png" },
+      });
+
+    await libraryCache.saveFullBookPackage({
+      book_id: "book-safe",
+      book_title: "Original Book",
+      cover_url: "https://example.com/original-cover.png",
+      images: [
+        {
+          page: 1,
+          url: "https://example.com/original-page-1.png",
+        },
+      ],
+      pages: [
+        {
+          page_number: 1,
+          content: {
+            text_content_of_this_page: "Original page",
+          },
+        },
+      ],
+    });
+
+    global.fetch.mockReset();
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      arrayBuffer: async () => makeArrayBuffer(""),
+      headers: { get: () => "image/png" },
+    });
+
+    await expect(
+      libraryCache.saveFullBookPackage({
+        book_id: "book-safe",
+        book_title: "Replacement Book",
+        cover_url: "https://example.com/replacement-cover.png",
+        images: [],
+        pages: [
+          {
+            page_number: 1,
+            content: {
+              text_content_of_this_page: "Replacement page",
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow("Failed to fetch asset. status=400");
+
+    const cachedBook = await libraryCache.getCachedFullBook("book-safe");
+
+    expect(cachedBook).toEqual(
+      expect.objectContaining({
+        book_id: "book-safe",
+        book_title: "Original Book",
+      }),
+    );
+    expect(cachedBook.cover_url).toBe("blob:generated-1");
+    expect(cachedBook.images[0].url).toBe("blob:generated-2");
   });
 });


### PR DESCRIPTION
# Align Cache Freshness With Signed URL Expiry

## Summary
Implement a frontend-only cache freshness fix that separates durable cached metadata from short-lived signed URLs.

The core change is behavioral: cached records may remain valid for durable metadata even after embedded signed URLs are no longer usable. For shelf data, the app will continue to use cached metadata for up to 7 days, but it will treat cached cover URLs as independently expiring and suppress expired covers while refreshing the shelf in the background. For full-book cache hits, the app will continue to rely on cached bytes for cover/page images and will not trust persisted signed URL fields at runtime. Use a 5-minute expiry buffer when deciding whether a signed URL is still usable.

| Asset type | Where cached | Current cache TTL | Associated signed URL fields | Current signed URL lifetime |
| --- | --- | --- | --- | --- |
| Shelf book metadata | `localStorage` shelf metadata cache | 7 days | `cover_url` | 1 hour |
| Full-book package metadata | IndexedDB full-book package cache | 3 days | `json_url`, persisted source `cover_url`, persisted source `images[].url` | 1 hour |
| Full-book cover/image bytes | IndexedDB asset records | 3 days | Original fetch source URLs used only at cache-write time | 1 hour |
| Live detail response | In-memory/runtime only unless promoted into cache | No explicit frontend TTL | `json_url`, `cover.url`, `images[].url` | 1 hour |

## Key Changes
### Shelf behavior
- Keep the 7-day shelf metadata cache for durable fields such as `book_id`, `book_title`, and `is_archived`.
- Add frontend helpers that evaluate signed URL usability from backend expiry timestamps with a 5-minute safety buffer.
- When hydrating shelf metadata from cache, keep entries even if `cover_url` is stale.
- If a cached shelf cover URL is expired or near expiry, suppress the cover image instead of rendering the stale URL.
- Trigger a background shelf refresh whenever cached shelf data is shown and any visible cover URL is stale or near expiry.
- Show the shelf entry immediately with metadata intact and no cover until fresh shelf data arrives.

### Full-book behavior
- Keep the existing IndexedDB byte cache for full-book covers and page images.
- Preserve current cache-hit behavior that reconstructs browser-local `blob:` URLs from cached bytes.
- Treat persisted signed URL fields inside cached full-book packages as non-authoritative runtime metadata.
- On full-book cache hits, do not rely on cached `json_url`, cached remote `cover_url`, or cached remote image URLs to reopen or render the book.
- On full-book cache misses, fetch fresh detail metadata first, then use the fresh `json_url` and fresh signed asset URLs for the immediate network path and cache-write path.
- Keep signed source URLs in the stored package only for compatibility/bookkeeping; ignore them at runtime on cache hits rather than stripping or refreshing them in this change.

### Frontend contract handling
- Keep the current backend response shape unchanged.
- Use existing backend expiry fields as the source of truth for URL usability.
- Centralize signed-URL freshness checks in frontend cache logic instead of scattering expiry comparisons across components.
- Do not shorten all frontend cache TTLs to 1 hour; only shorten effective URL usability, not durable metadata lifetime.

### Failure handling
- Expired shelf cover URLs should degrade to “metadata without cover,” not “broken image.”
- If a full-book cache save fails because signed asset URLs are no longer usable, fail that cache write cleanly without corrupting an existing healthy cached package.
- Full-book open order remains:
  1. valid cached byte-backed package
  2. fresh detail fetch plus fresh `json_url`
  3. user-visible error

## Public Interfaces / Types
- No backend API shape changes in scope.
- Frontend cache helpers should expose explicit signed-URL usability checks based on backend timestamps plus the 5-minute buffer.
- Frontend normalized book data should continue to distinguish:
  - durable metadata
  - temporary signed URLs
  - local object URLs reconstructed from cached bytes

## Test Plan
- Shelf cache:
  - cached shelf metadata with unexpired `cover_url` renders cover normally
  - cached shelf metadata with expired or near-expiry `cover_url` still renders title/metadata
  - expired cached shelf cover is suppressed rather than shown as a broken image
  - stale visible shelf covers trigger a background shelf refresh
  - refreshed shelf data repopulates covers after stale hydration
- Full-book cache:
  - cached full-book package reopens successfully after original signed image URLs would have expired
  - cache hit uses reconstructed local object URLs for cover and page images
  - runtime behavior does not depend on persisted signed URL fields inside the cached package
  - expired or missing cached asset records invalidate the package cleanly
  - failed asset fetch during cache save does not leave a partially poisoned package behind
- Live fetch flow:
  - book open after cache miss depends on fresh detail metadata and fresh `json_url`
  - stale `json_url` from cached package metadata is not used on cache hit
- Regression coverage:
  - existing byte-cache behavior remains intact
  - object URL lifecycle and revocation still work
  - shelf and book-open flows remain functional in local-storage mode and cloud-storage mode

## Assumptions
- Backend signed URL lifetime stays at 1 hour.
- This work is frontend-only and relies on existing backend expiry fields.
- Use a 5-minute freshness buffer for signed URLs.
- Shelf-cover byte caching remains out of scope for this change and can be handled later as a separate enhancement.
