### PR TITLE
UI improvements

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -507,6 +507,7 @@ const App = () => {
       setBook(null);
       alert("Error generating book. Please try again.");
     } finally {
+      setTheme("");
       setLoading(false);
     }
   };

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -48,6 +48,7 @@ const createDeferred = () => {
 
 beforeEach(() => {
   window.localStorage.clear();
+  window.alert = jest.fn();
   global.URL.createObjectURL = jest.fn((value) => `blob:${String(value)}`);
   global.URL.revokeObjectURL = jest.fn();
   mockEnforceCacheBudget.mockResolvedValue(undefined);
@@ -289,6 +290,151 @@ test("deduplicates repeated clicks while the same book is still opening", async 
   await waitFor(() => {
     expect(global.fetch).toHaveBeenCalledTimes(3);
   });
+});
+
+test("disables generation controls while a book is generating", async () => {
+  const generateRequest = createDeferred();
+
+  global.fetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    })
+    .mockReturnValueOnce(generateRequest.promise);
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  const themeInput = screen.getByPlaceholderText(/enter a theme for your book/i);
+  const generateButton = screen.getByRole("button", { name: /generate book/i });
+
+  fireEvent.change(themeInput, { target: { value: "Sky pirates" } });
+
+  await act(async () => {
+    fireEvent.click(generateButton);
+  });
+
+  expect(generateButton).toBeDisabled();
+  expect(screen.getByRole("button", { name: /generating/i })).toBeDisabled();
+  expect(themeInput).toBeDisabled();
+  expect(themeInput).toHaveStyle({
+    backgroundColor: "#E5E7EB",
+    color: "#4B5563",
+    cursor: "not-allowed",
+    opacity: "1",
+  });
+  expect(themeInput).toHaveValue("Sky pirates");
+});
+
+test("clears the theme after a successful generation", async () => {
+  global.fetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        book_id: "generated-book-1",
+        book_title: "Generated Book",
+        json_url: "https://example.com/generated-book-1.json",
+        cover: {
+          url: "https://example.com/generated-book-1-cover.png",
+        },
+        images: [],
+        is_archived: false,
+      }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        pages: [
+          {
+            page_number: 1,
+            content: {
+              text_content_of_this_page: "Generated page text",
+            },
+          },
+        ],
+      }),
+    });
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  const themeInput = screen.getByPlaceholderText(/enter a theme for your book/i);
+
+  fireEvent.change(themeInput, { target: { value: "Moonlit jungle" } });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /generate book/i }));
+  });
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenNthCalledWith(2, "http://localhost/books/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ theme: "Moonlit jungle" }),
+    });
+  });
+
+  await screen.findByRole("button", { name: /close modal/i });
+  expect(themeInput).toHaveValue("");
+});
+
+test("clears the theme after a failed generation request", async () => {
+  global.fetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    })
+    .mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    });
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  const themeInput = screen.getByPlaceholderText(/enter a theme for your book/i);
+
+  fireEvent.change(themeInput, { target: { value: "Stormy forest" } });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /generate book/i }));
+  });
+
+  await waitFor(() => {
+    expect(window.alert).toHaveBeenCalledWith("Error generating book. Please try again.");
+  });
+  expect(themeInput).toHaveValue("");
+});
+
+test("does not clear the theme when empty-theme validation blocks generation", async () => {
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => [],
+  });
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  const themeInput = screen.getByPlaceholderText(/enter a theme for your book/i);
+  const generateButton = screen.getByRole("button", { name: /generate book/i });
+
+  fireEvent.change(themeInput, { target: { value: "   " } });
+
+  await act(async () => {
+    fireEvent.click(generateButton);
+  });
+
+  expect(window.alert).toHaveBeenCalledWith("Please enter a theme to generate a book.");
+  expect(themeInput).toHaveValue("   ");
+  expect(global.fetch).toHaveBeenCalledTimes(1);
 });
 
 test("revokes cached book object URLs when the modal closes, not when it opens", async () => {

--- a/frontend/src/components/BookList.js
+++ b/frontend/src/components/BookList.js
@@ -10,6 +10,7 @@ const TAB_BAR_SIDE_PADDING = 18;
 const TAB_HEIGHT = 52;
 const TAB_BAR_OVERLAP = 8;
 const ACTIVE_TAB_BRIDGE_HEIGHT = 12;
+const MOBILE_GRID_MEDIA_QUERY = "(max-width: 600px)";
 
 const usePrefersReducedMotion = () => {
   const getPreference = () =>
@@ -41,6 +42,38 @@ const usePrefersReducedMotion = () => {
   }, []);
 
   return prefersReducedMotion;
+};
+
+const useIsMobileGrid = () => {
+  const getPreference = () =>
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia(MOBILE_GRID_MEDIA_QUERY).matches;
+
+  const [isMobileGrid, setIsMobileGrid] = useState(getPreference);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia(MOBILE_GRID_MEDIA_QUERY);
+    const handleChange = (event) => {
+      setIsMobileGrid(event.matches);
+    };
+
+    setIsMobileGrid(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  return isMobileGrid;
 };
 
 const BookCoverImage = ({ bookId, coverUrl, sourceKind, bookTitle, onSizeChange }) => {
@@ -139,40 +172,92 @@ const BookList = ({
   archiveActionBookIds = [],
 }) => {
   const buttonRefs = useRef({});
+  const cardInnerRefs = useRef({});
   const itemRefs = useRef({});
-  const [maxButtonHeight, setMaxButtonHeight] = useState(null);
   const [layoutVersion, setLayoutVersion] = useState(0);
   const [activeTab, setActiveTab] = useState(BOOK_SHELF_TAB);
   const [flippedBookId, setFlippedBookId] = useState(null);
   const prefersReducedMotion = usePrefersReducedMotion();
+  const isMobileGrid = useIsMobileGrid();
   const pendingArchiveBookIds = new Set(archiveActionBookIds);
   const visibleBooks = books.filter((book) =>
     activeTab === BOOK_SHELF_TAB ? !book.is_archived : book.is_archived,
   );
 
   useLayoutEffect(() => {
-    if (activeTab !== BOOK_SHELF_TAB || visibleBooks.length === 0) {
-      setMaxButtonHeight(null);
+    if (visibleBooks.length === 0) {
       return;
     }
 
-    const buttons = Object.values(buttonRefs.current).filter(Boolean);
-    if (buttons.length === 0) {
+    const buttonEntries = visibleBooks
+      .map((book) => ({
+        bookId: book.book_id,
+        button: buttonRefs.current[book.book_id] ?? null,
+        cardInner: cardInnerRefs.current[book.book_id] ?? null,
+      }))
+      .filter((entry) => entry.button && entry.cardInner);
+
+    if (buttonEntries.length === 0) {
       return;
     }
 
-    buttons.forEach((button) => {
+    buttonEntries.forEach(({ button, cardInner }) => {
       button.style.height = "auto";
+      cardInner.style.height = "auto";
     });
 
-    const tallestHeight = Math.ceil(
-      Math.max(...buttons.map((button) => button.getBoundingClientRect().height)),
-    );
+    const measuredEntries = buttonEntries
+      .map(({ bookId, button }) => {
+        const rect = button.getBoundingClientRect();
+        return {
+          bookId,
+          height: Math.ceil(rect.height),
+          top: rect.top,
+          left: rect.left,
+        };
+      })
+      .sort((left, right) => {
+        if (left.top !== right.top) {
+          return left.top - right.top;
+        }
+        return left.left - right.left;
+      });
 
-    setMaxButtonHeight((currentHeight) =>
-      currentHeight === tallestHeight ? currentHeight : tallestHeight,
-    );
-  }, [activeTab, books, layoutVersion, visibleBooks.length]);
+    const rowTolerance = 4;
+    const rows = [];
+    measuredEntries.forEach((entry) => {
+      const row = rows.find((candidate) => Math.abs(candidate.top - entry.top) <= rowTolerance);
+      if (row) {
+        row.entries.push(entry);
+        row.maxHeight = Math.max(row.maxHeight, entry.height);
+        return;
+      }
+
+      rows.push({
+        top: entry.top,
+        maxHeight: entry.height,
+        entries: [entry],
+      });
+    });
+
+    const heightByBookId = rows.reduce((heights, row) => {
+      row.entries.forEach((entry) => {
+        heights[entry.bookId] = row.maxHeight;
+      });
+      return heights;
+    }, {});
+
+    buttonEntries.forEach(({ bookId, button, cardInner }) => {
+      const nextHeight = heightByBookId[bookId];
+      if (!nextHeight) {
+        return;
+      }
+
+      const heightValue = `${nextHeight}px`;
+      button.style.height = heightValue;
+      cardInner.style.height = heightValue;
+    });
+  }, [activeTab, books, layoutVersion, visibleBooks]);
 
   useEffect(() => {
     const handleResize = () => {
@@ -321,7 +406,12 @@ const BookList = ({
     }
 
     return (
-      <ul style={styles.list}>
+      <ul
+        style={{
+          ...styles.list,
+          ...(isMobileGrid ? styles.mobileList : {}),
+        }}
+      >
         {visibleBooks.map((book) => (
           <li
             key={book.book_id}
@@ -343,6 +433,14 @@ const BookList = ({
               }}
             >
               <div
+                ref={(element) => {
+                  if (element) {
+                    cardInnerRefs.current[book.book_id] = element;
+                    return;
+                  }
+
+                  delete cardInnerRefs.current[book.book_id];
+                }}
                 style={{
                   ...styles.cardInner,
                   ...(flippedBookId === book.book_id
@@ -350,7 +448,6 @@ const BookList = ({
                       ? styles.cardInnerReducedMotionFlipped
                       : styles.cardInnerFlipped
                     : {}),
-                  height: maxButtonHeight ? `${maxButtonHeight}px` : "auto",
                 }}
               >
                 <div
@@ -377,13 +474,20 @@ const BookList = ({
                     aria-label={book.book_title}
                     style={{
                       ...styles.bookButton,
-                      height: maxButtonHeight ? `${maxButtonHeight}px` : "auto",
+                      ...(activeTab === ARCHIVE_TAB ? styles.archiveBookButton : {}),
                     }}
                     onClick={() => {
                       onSelectBook(book.book_id);
                     }}
                   >
-                    <span style={styles.bookTitle}>{book.book_title}</span>
+                    <span
+                      style={{
+                        ...styles.bookTitle,
+                        ...(activeTab === ARCHIVE_TAB ? styles.archiveBookTitle : {}),
+                      }}
+                    >
+                      {book.book_title}
+                    </span>
                     <div style={styles.coverSlot}>
                       <BookCoverImage
                         bookId={book.book_id}
@@ -397,7 +501,10 @@ const BookList = ({
                   <button
                     type="button"
                     aria-label={`More actions for ${book.book_title}`}
-                    style={styles.frontActionButton}
+                    style={{
+                      ...styles.frontActionButton,
+                      ...(activeTab === ARCHIVE_TAB ? styles.archiveFrontActionButton : {}),
+                    }}
                     onClick={(event) => handleFlipToggle(event, book.book_id)}
                   >
                     <span style={styles.materialSymbol}>more_vert</span>
@@ -408,6 +515,7 @@ const BookList = ({
                   style={{
                     ...styles.cardFace,
                     ...styles.cardBack,
+                    ...(activeTab === ARCHIVE_TAB ? styles.archiveCardBack : {}),
                     ...(prefersReducedMotion ? styles.cardBackReducedMotion : {}),
                     ...(prefersReducedMotion
                       ? flippedBookId === book.book_id
@@ -419,16 +527,29 @@ const BookList = ({
                   <button
                     type="button"
                     aria-label={`Return to cover for ${book.book_title}`}
-                    style={styles.backActionButton}
+                    style={{
+                      ...styles.backActionButton,
+                      ...(activeTab === ARCHIVE_TAB ? styles.archiveBackActionButton : {}),
+                    }}
                     onClick={(event) => handleFlipToggle(event, book.book_id)}
                   >
                     <span style={styles.materialSymbol}>undo</span>
                   </button>
                   <div style={styles.backContent}>
-                    <p style={styles.backTitle}>{book.book_title}</p>
+                    <p
+                      style={{
+                        ...styles.backTitle,
+                        ...(activeTab === ARCHIVE_TAB ? styles.archiveBackTitle : {}),
+                      }}
+                    >
+                      {book.book_title}
+                    </p>
                     <button
                       type="button"
-                      style={styles.menuActionButton}
+                      style={{
+                        ...styles.menuActionButton,
+                        ...(activeTab === ARCHIVE_TAB ? styles.archiveMenuActionButton : {}),
+                      }}
                       disabled={pendingArchiveBookIds.has(book.book_id)}
                       onClick={(event) => handleArchiveAction(event, book)}
                     >
@@ -604,6 +725,9 @@ const styles = {
     padding: 0,
     margin: 0,
   },
+  mobileList: {
+    gridTemplateColumns: "1fr",
+  },
   listItem: {
     display: "flex",
   },
@@ -657,7 +781,7 @@ const styles = {
     flexDirection: 'column',
     width: "100%",
     minHeight: '220px',
-    padding: "16px",
+    padding: "16px 16px 24px 24px",
     backgroundColor: "#FFCC00",
     border: "none",
     borderRadius: "8px",
@@ -669,15 +793,18 @@ const styles = {
     position: "relative",
     outline: "none",
   },
+  archiveBookButton: {
+    backgroundColor: "#CA054D",
+  },
   frontActionButton: {
     position: "absolute",
-    top: "10px",
-    right: "10px",
+    bottom: "10px",
+    left: "10px",
     width: "42px",
     height: "42px",
     border: "none",
     borderRadius: "999px",
-    backgroundColor: "rgba(202, 5, 77, 0.3)",
+    backgroundColor: "rgba(202, 5, 77, 0.24)",
     color: "#FFFCF0",
     backdropFilter: "blur(4px)",
     WebkitBackdropFilter: "blur(4px)",
@@ -687,6 +814,10 @@ const styles = {
     justifyContent: "center",
     zIndex: 2,
   },
+  archiveFrontActionButton: {
+    backgroundColor: "rgba(255, 204, 0, 0.2)",
+    color: "#FFCC00",
+  },
   bookTitle: {
     fontSize: "20px",
     color: "#CA054D",
@@ -694,6 +825,9 @@ const styles = {
     overflowWrap: "break-word",
     width: '100%',
     flexShrink: 0,
+  },
+  archiveBookTitle: {
+    color: "#FFCC00",
   },
   coverSlot: {
     width: "100%",
@@ -732,6 +866,9 @@ const styles = {
     alignItems: "center",
     justifyContent: "center",
   },
+  archiveCardBack: {
+    background: "linear-gradient(160deg, rgba(202, 5, 77, 0.98), rgba(138, 0, 51, 0.98))",
+  },
   cardBackReducedMotion: {
     transform: "none",
   },
@@ -749,6 +886,9 @@ const styles = {
     fontWeight: "600",
     textAlign: "center",
   },
+  archiveBackTitle: {
+    color: "#FFCC00",
+  },
   backActionButton: {
     position: "absolute",
     top: "10px",
@@ -764,6 +904,10 @@ const styles = {
     alignItems: "center",
     justifyContent: "center",
   },
+  archiveBackActionButton: {
+    backgroundColor: "#FFCC00",
+    color: "#CA054D",
+  },
   menuActionButton: {
     width: "100%",
     maxWidth: "220px",
@@ -775,6 +919,10 @@ const styles = {
     fontSize: "15px",
     fontWeight: "700",
     cursor: "pointer",
+  },
+  archiveMenuActionButton: {
+    backgroundColor: "#FFCC00",
+    color: "#CA054D",
   },
   materialSymbol: {
     fontFamily: '"Material Symbols Outlined"',

--- a/frontend/src/components/BookList.test.js
+++ b/frontend/src/components/BookList.test.js
@@ -1,5 +1,73 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import BookList from "./BookList";
+
+const createMatchMediaController = () => {
+  const listenersByQuery = new Map();
+  const mediaQueryListsByQuery = new Map();
+  const matchStateByQuery = new Map();
+
+  const ensureQueryState = (query) => {
+    if (!listenersByQuery.has(query)) {
+      listenersByQuery.set(query, new Set());
+    }
+
+    if (!matchStateByQuery.has(query)) {
+      matchStateByQuery.set(query, false);
+    }
+  };
+
+  const notifyListeners = (query, matches) => {
+    const listeners = listenersByQuery.get(query) ?? new Set();
+    const event = { matches, media: query };
+
+    listeners.forEach((listener) => listener(event));
+  };
+
+  const matchMedia = jest.fn((query) => {
+    ensureQueryState(query);
+
+    if (mediaQueryListsByQuery.has(query)) {
+      return mediaQueryListsByQuery.get(query);
+    }
+
+    const mediaQueryList = {
+      media: query,
+      get matches() {
+        return matchStateByQuery.get(query) ?? false;
+      },
+      onchange: null,
+      addEventListener: jest.fn((eventName, listener) => {
+        if (eventName === "change") {
+          listenersByQuery.get(query).add(listener);
+        }
+      }),
+      removeEventListener: jest.fn((eventName, listener) => {
+        if (eventName === "change") {
+          listenersByQuery.get(query).delete(listener);
+        }
+      }),
+      addListener: jest.fn((listener) => {
+        listenersByQuery.get(query).add(listener);
+      }),
+      removeListener: jest.fn((listener) => {
+        listenersByQuery.get(query).delete(listener);
+      }),
+      dispatchEvent: jest.fn(),
+    };
+
+    mediaQueryListsByQuery.set(query, mediaQueryList);
+    return mediaQueryList;
+  });
+
+  return {
+    matchMedia,
+    setMatches(query, matches) {
+      ensureQueryState(query);
+      matchStateByQuery.set(query, matches);
+      notifyListeners(query, matches);
+    },
+  };
+};
 
 const baseProps = {
   loading: false,
@@ -13,10 +81,18 @@ const renderBookList = (books) =>
   render(<BookList {...baseProps} books={books} />);
 
 const exactName = (label) => new RegExp(`^${label}$`, "i");
+const mobileGridQuery = "(max-width: 600px)";
+let matchMediaController;
 
 describe("BookList", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    matchMediaController = createMatchMediaController();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: matchMediaController.matchMedia,
+    });
   });
 
   test("renders the tab bar with Book Shelf active by default", () => {
@@ -81,6 +157,73 @@ describe("BookList", () => {
     expect(archiveTab.querySelector("span")).not.toHaveStyle({ transform: expect.any(String) });
   });
 
+  test("uses two columns by default on desktop", () => {
+    renderBookList([
+      {
+        book_id: "desktop-grid-book-1",
+        book_title: "Desktop Grid Book 1",
+        is_archived: false,
+      },
+      {
+        book_id: "desktop-grid-book-2",
+        book_title: "Desktop Grid Book 2",
+        is_archived: false,
+      },
+    ]);
+
+    const list = screen.getByRole("list");
+
+    expect(list).toHaveStyle({ gridTemplateColumns: "repeat(2, 1fr)" });
+  });
+
+  test("uses one column on mobile", () => {
+    matchMediaController.setMatches(mobileGridQuery, true);
+
+    renderBookList([
+      {
+        book_id: "mobile-grid-book-1",
+        book_title: "Mobile Grid Book 1",
+        is_archived: false,
+      },
+      {
+        book_id: "mobile-grid-book-2",
+        book_title: "Mobile Grid Book 2",
+        is_archived: false,
+      },
+    ]);
+
+    const list = screen.getByRole("list");
+
+    expect(list).toHaveStyle({ gridTemplateColumns: "1fr" });
+  });
+
+  test("updates the grid when the mobile media query changes", () => {
+    renderBookList([
+      {
+        book_id: "responsive-grid-book-1",
+        book_title: "Responsive Grid Book 1",
+        is_archived: false,
+      },
+      {
+        book_id: "responsive-grid-book-2",
+        book_title: "Responsive Grid Book 2",
+        is_archived: false,
+      },
+    ]);
+
+    const list = screen.getByRole("list");
+
+    expect(list).toHaveStyle({ gridTemplateColumns: "repeat(2, 1fr)" });
+
+    act(() => {
+      matchMediaController.setMatches(mobileGridQuery, true);
+    });
+
+    expect(list).toHaveStyle({ gridTemplateColumns: "1fr" });
+    expect(screen.getByRole("button", { name: exactName("Responsive Grid Book 1") })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: exactName("Responsive Grid Book 2") })).toBeInTheDocument();
+  });
+
   test("renders title and cover image inside the book button when cover_url is present", () => {
     renderBookList([
       {
@@ -117,8 +260,27 @@ describe("BookList", () => {
       },
     ]);
 
-    expect(screen.getByRole("button", { name: exactName("Title Only") })).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: exactName("Title Only") });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveStyle({ backgroundColor: "#FFCC00" });
+    expect(within(button).getByText("Title Only")).toHaveStyle({ color: "#CA054D" });
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  test("renders archive cards with inverted front-face colors", () => {
+    renderBookList([
+      {
+        book_id: "archive-book-colors",
+        book_title: "Archived Colors",
+        is_archived: true,
+      },
+    ]);
+
+    fireEvent.click(screen.getByRole("tab", { name: /archive/i }));
+
+    const button = screen.getByRole("button", { name: exactName("Archived Colors") });
+    expect(button).toHaveStyle({ backgroundColor: "#CA054D" });
+    expect(within(button).getByText("Archived Colors")).toHaveStyle({ color: "#FFCC00" });
   });
 
   test("hides the image when it fails to load", async () => {
@@ -257,6 +419,8 @@ describe("BookList", () => {
   });
 
   test("switches to Archive and back to Book Shelf", () => {
+    matchMediaController.setMatches(mobileGridQuery, true);
+
     renderBookList([
       {
         book_id: "book-6",
@@ -270,14 +434,33 @@ describe("BookList", () => {
       },
     ]);
 
+    expect(screen.getByRole("list")).toHaveStyle({ gridTemplateColumns: "1fr" });
+
     fireEvent.click(screen.getByRole("tab", { name: /archive/i }));
 
     expect(screen.getByRole("tab", { name: /archive/i })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("button", { name: exactName("Archived Book") })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: exactName("Archive Toggle Book") })).not.toBeInTheDocument();
+    expect(screen.getByRole("list")).toHaveStyle({ gridTemplateColumns: "1fr" });
+    const archivedFrontButton = screen.getByRole("button", { name: exactName("Archived Book") });
+    expect(archivedFrontButton).toHaveStyle({
+      backgroundColor: "#CA054D",
+    });
+    expect(within(archivedFrontButton).getByText("Archived Book")).toHaveStyle({ color: "#FFCC00" });
 
     fireEvent.click(screen.getByRole("button", { name: /more actions for archived book/i }));
     expect(screen.getByRole("button", { name: /restore to book shelf/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /restore to book shelf/i }).previousSibling).toHaveStyle({
+      color: "#FFCC00",
+    });
+    expect(screen.getByRole("button", { name: /return to cover for archived book/i })).toHaveStyle({
+      backgroundColor: "#FFCC00",
+      color: "#CA054D",
+    });
+    expect(screen.getByRole("button", { name: /restore to book shelf/i })).toHaveStyle({
+      backgroundColor: "#FFCC00",
+      color: "#CA054D",
+    });
 
     fireEvent.click(screen.getByRole("tab", { name: /book shelf/i }));
 
@@ -308,13 +491,178 @@ describe("BookList", () => {
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
+  test("equalizes card heights within each desktop row only", async () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+
+    HTMLElement.prototype.getBoundingClientRect = jest.fn(function mockRect() {
+      if (this.tagName === "BUTTON" && this.getAttribute("role") !== "tab") {
+        if (this.getAttribute("aria-label") === "Row One Short") {
+          return { width: 200, height: 180, top: 0, left: 0, right: 200, bottom: 180 };
+        }
+
+        if (this.getAttribute("aria-label") === "Row One Tall") {
+          return { width: 200, height: 320, top: 0, left: 220, right: 420, bottom: 320 };
+        }
+
+        if (this.getAttribute("aria-label") === "Row Two Short") {
+          return { width: 200, height: 210, top: 340, left: 0, right: 200, bottom: 550 };
+        }
+
+        if (this.getAttribute("aria-label") === "Row Two Tall") {
+          return { width: 200, height: 260, top: 340, left: 220, right: 420, bottom: 600 };
+        }
+      }
+
+      return { width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 };
+    });
+
+    renderBookList([
+      {
+        book_id: "row-1-short",
+        book_title: "Row One Short",
+        is_archived: false,
+      },
+      {
+        book_id: "row-1-tall",
+        book_title: "Row One Tall",
+        is_archived: false,
+      },
+      {
+        book_id: "row-2-short",
+        book_title: "Row Two Short",
+        is_archived: false,
+      },
+      {
+        book_id: "row-2-tall",
+        book_title: "Row Two Tall",
+        is_archived: false,
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: exactName("Row One Short") })).toHaveStyle({
+        height: "320px",
+      });
+      expect(screen.getByRole("button", { name: exactName("Row One Tall") })).toHaveStyle({
+        height: "320px",
+      });
+      expect(screen.getByRole("button", { name: exactName("Row Two Short") })).toHaveStyle({
+        height: "260px",
+      });
+      expect(screen.getByRole("button", { name: exactName("Row Two Tall") })).toHaveStyle({
+        height: "260px",
+      });
+    });
+
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
+  test("equalizes archive card heights within each row", async () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+
+    HTMLElement.prototype.getBoundingClientRect = jest.fn(function mockRect() {
+      if (this.tagName === "BUTTON" && this.getAttribute("role") !== "tab") {
+        if (this.getAttribute("aria-label") === "Archive Short") {
+          return { width: 200, height: 190, top: 0, left: 0, right: 200, bottom: 190 };
+        }
+
+        if (this.getAttribute("aria-label") === "Archive Tall") {
+          return { width: 200, height: 300, top: 0, left: 220, right: 420, bottom: 300 };
+        }
+      }
+
+      return { width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 };
+    });
+
+    renderBookList([
+      {
+        book_id: "archive-short",
+        book_title: "Archive Short",
+        is_archived: true,
+      },
+      {
+        book_id: "archive-tall",
+        book_title: "Archive Tall",
+        is_archived: true,
+      },
+    ]);
+
+    fireEvent.click(screen.getByRole("tab", { name: /archive/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: exactName("Archive Short") })).toHaveStyle({
+        height: "300px",
+      });
+      expect(screen.getByRole("button", { name: exactName("Archive Tall") })).toHaveStyle({
+        height: "300px",
+      });
+    });
+
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
+  test("keeps single-column mobile rows at their own measured heights", async () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    matchMediaController.setMatches(mobileGridQuery, true);
+
+    HTMLElement.prototype.getBoundingClientRect = jest.fn(function mockRect() {
+      if (this.tagName === "BUTTON" && this.getAttribute("role") !== "tab") {
+        if (this.getAttribute("aria-label") === "Mobile One") {
+          return { width: 200, height: 180, top: 0, left: 0, right: 200, bottom: 180 };
+        }
+
+        if (this.getAttribute("aria-label") === "Mobile Two") {
+          return { width: 200, height: 320, top: 340, left: 0, right: 200, bottom: 660 };
+        }
+
+        if (this.getAttribute("aria-label") === "Mobile Three") {
+          return { width: 200, height: 240, top: 700, left: 0, right: 200, bottom: 940 };
+        }
+      }
+
+      return { width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 };
+    });
+
+    renderBookList([
+      {
+        book_id: "mobile-one",
+        book_title: "Mobile One",
+        is_archived: false,
+      },
+      {
+        book_id: "mobile-two",
+        book_title: "Mobile Two",
+        is_archived: false,
+      },
+      {
+        book_id: "mobile-three",
+        book_title: "Mobile Three",
+        is_archived: false,
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: exactName("Mobile One") })).toHaveStyle({
+        height: "180px",
+      });
+      expect(screen.getByRole("button", { name: exactName("Mobile Two") })).toHaveStyle({
+        height: "320px",
+      });
+      expect(screen.getByRole("button", { name: exactName("Mobile Three") })).toHaveStyle({
+        height: "240px",
+      });
+    });
+
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
   test("keeps book buttons interactive after a relayout trigger", async () => {
     const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
 
     HTMLElement.prototype.getBoundingClientRect = jest.fn(function mockRect() {
       if (this.tagName === "BUTTON" && this.getAttribute("role") !== "tab") {
-        if (this.textContent.includes("Tall Book")) {
-          return { width: 200, height: 320, top: 0, left: 0, right: 200, bottom: 320 };
+        if (this.getAttribute("aria-label") === "Tall Book") {
+          return { width: 200, height: 320, top: 0, left: 220, right: 420, bottom: 320 };
         }
 
         return { width: 200, height: 180, top: 0, left: 0, right: 200, bottom: 180 };
@@ -340,9 +688,16 @@ describe("BookList", () => {
     fireEvent.load(screen.getByRole("img", { name: /cover for tall book/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: exactName("Short Book") })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: exactName("Tall Book") })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: exactName("Short Book") })).toHaveStyle({
+        height: "320px",
+      });
+      expect(screen.getByRole("button", { name: exactName("Tall Book") })).toHaveStyle({
+        height: "320px",
+      });
     });
+
+    fireEvent.click(screen.getByRole("button", { name: exactName("Short Book") }));
+    expect(baseProps.onSelectBook).toHaveBeenCalledWith("book-7");
 
     HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   });

--- a/frontend/src/components/ThemeInput.js
+++ b/frontend/src/components/ThemeInput.js
@@ -117,6 +117,14 @@ const ThemeInput = ({
             overflow: hidden;
           }
 
+          .theme-input::placeholder {
+            color: #6b7280;
+          }
+
+          .theme-input:disabled::placeholder {
+            color: #7c8798;
+          }
+
           /* Sparks Animation */
           @keyframes spark {
             from {
@@ -188,7 +196,12 @@ const ThemeInput = ({
           onChange={(e) => setTheme(e.target.value)}
           placeholder="Enter a theme for your book"
           required
-          style={styles.input}
+          disabled={loading}
+          className="theme-input"
+          style={{
+            ...styles.input,
+            ...(loading ? styles.inputDisabled : {}),
+          }}
         />
         <button
           type="submit"
@@ -239,6 +252,13 @@ const styles = {
     fontSize: "16px",
     marginBottom: "10px",
     boxShadow: "rgba(0, 0, 0, 0.25) 1.95px 1.95px 2.6px",
+  },
+  inputDisabled: {
+    backgroundColor: "#E5E7EB",
+    border: "1px solid #B8C0CC",
+    color: "#4B5563",
+    cursor: "not-allowed",
+    opacity: 1,
   },
   generateButton: {
     padding: "10px 20px",


### PR DESCRIPTION
- Updated the book cards so the more_vert action sits bottom-left without covering titles, and made the button slightly less visually heavy.
- Made the shelf/archive grid responsive: desktop stays two-up, mobile becomes one card per row.
- Improved generation UX: while a book is generating, the generate controls disable, the theme field stays visible but greyed out, and the theme clears when generation finishes or fails.
- Inverted archived card colors so archive cards clearly differ from shelf cards, including their flipped side.
- Standardized card heights by row in both Book Shelf and Archive so cards align cleanly within each row.