### PR TITLE
Add Favorites tab feature

### DIFF
--- a/backend/src/api/models/book_models.py
+++ b/backend/src/api/models/book_models.py
@@ -200,13 +200,15 @@ class BookResponse(BaseModel):
     json_url: str  # Pre-signed URL for the book's JSON metadata
     cover: Optional[CoverResponse] = None
     is_archived: bool = False
+    is_favorite: bool = False
     images: List[
         ImageResponse
     ]  # List of images with their URLs and expiration metadata
 
 
-class ArchiveBookRequest(BaseModel):
-    is_archived: bool
+class UpdateBookLibraryStateRequest(BaseModel):
+    is_archived: Optional[bool] = None
+    is_favorite: Optional[bool] = None
 
 
 # Add the following lines to resolve forward references

--- a/backend/src/api/routers/books.py
+++ b/backend/src/api/routers/books.py
@@ -15,7 +15,7 @@ from api.models.book_models import (
     Book,
     BookResponse,
     BookCreateRequest,
-    ArchiveBookRequest,
+    UpdateBookLibraryStateRequest,
     CoverResponse,
     ImageResponse,
 )
@@ -92,6 +92,7 @@ async def create_book(book_request: BookCreateRequest):
             expires_at=expires_at,
             json_url=json_url,
             is_archived=False,
+            is_favorite=False,
             cover=(
                 CoverResponse(
                     url=book.cover["url"],
@@ -352,27 +353,34 @@ async def fetch_book_by_id(book_id: str):
         raise HTTPException(status_code=500, detail="Error fetching book.")
 
 
-@router.patch("/{book_id}/archive/", response_model=BookResponse)
-async def update_book_archive_state(book_id: str, archive_request: ArchiveBookRequest):
+@router.patch("/{book_id}/library-state/", response_model=BookResponse)
+async def update_book_library_state(
+    book_id: str, library_state_request: UpdateBookLibraryStateRequest
+):
     """
-    Updates archive state for a specific book.
+    Updates persisted library state for a specific book.
     """
     logger.info(
-        "Received request to update archive state for book_id=%s is_archived=%s",
+        "Received request to update library state for book_id=%s is_archived=%s is_favorite=%s",
         book_id,
-        archive_request.is_archived,
+        library_state_request.is_archived,
+        library_state_request.is_favorite,
     )
     try:
         get_book_by_id(book_id)
-        save_book_library_state(book_id, archive_request.is_archived)
+        save_book_library_state(
+            book_id,
+            is_archived=library_state_request.is_archived,
+            is_favorite=library_state_request.is_favorite,
+        )
         return get_book_by_id(book_id)
     except ValueError as e:
         logger.error(str(e))
         raise HTTPException(status_code=404, detail="Book not found.")
     except Exception as e:
         logger.exception(
-            "Unexpected error updating archive state for book_id=%s: %s",
+            "Unexpected error updating library state for book_id=%s: %s",
             book_id,
             e,
         )
-        raise HTTPException(status_code=500, detail="Error updating archive state.")
+        raise HTTPException(status_code=500, detail="Error updating library state.")

--- a/backend/src/core/content_generation.py
+++ b/backend/src/core/content_generation.py
@@ -621,7 +621,7 @@ async def generate_book(theme: str, request_id: Optional[str] = None) -> Book:
                     "prompt_path_version": prompt_path_version,
                 },
             )
-            save_book_library_state(book_id_str, False)
+            save_book_library_state(book_id_str, is_archived=False, is_favorite=False)
             _capture_stage_duration(stage_timings, "book_json_persist", stage_started)
             progress.mark_work_completed(1.0, note="Book JSON persisted.")
 

--- a/backend/src/utils/general_utils.py
+++ b/backend/src/utils/general_utils.py
@@ -321,8 +321,59 @@ def _default_book_library_state(book_id: str) -> Dict[str, Any]:
     return {
         "book_id": str(book_id),
         "is_archived": False,
+        "is_favorite": False,
         "updated_at": datetime.now(timezone.utc).isoformat(),
     }
+
+
+def _normalize_book_library_state(state: Dict[str, Any]) -> Dict[str, Any]:
+    normalized_state = {
+        "book_id": str(state.get("book_id", "")),
+        "is_archived": bool(state.get("is_archived", False)),
+        "is_favorite": bool(state.get("is_favorite", False)),
+        "updated_at": state.get("updated_at")
+        or datetime.now(timezone.utc).isoformat(),
+    }
+
+    if normalized_state["is_archived"]:
+        normalized_state["is_favorite"] = False
+    elif normalized_state["is_favorite"]:
+        normalized_state["is_archived"] = False
+
+    return normalized_state
+
+
+def _resolve_book_library_state_update(
+    current_state: Dict[str, Any],
+    *,
+    is_archived: bool | None = None,
+    is_favorite: bool | None = None,
+) -> Dict[str, Any]:
+    resolved_state = {
+        "book_id": str(current_state.get("book_id", "")),
+        "is_archived": (
+            bool(is_archived)
+            if is_archived is not None
+            else bool(current_state.get("is_archived", False))
+        ),
+        "is_favorite": (
+            bool(is_favorite)
+            if is_favorite is not None
+            else bool(current_state.get("is_favorite", False))
+        ),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    if is_archived is True:
+        resolved_state["is_favorite"] = False
+    elif is_favorite is True:
+        resolved_state["is_archived"] = False
+    elif resolved_state["is_archived"]:
+        resolved_state["is_favorite"] = False
+    elif resolved_state["is_favorite"]:
+        resolved_state["is_archived"] = False
+
+    return resolved_state
 
 
 def get_book_library_state(book_id: str) -> Dict[str, Any]:
@@ -337,21 +388,28 @@ def get_book_library_state(book_id: str) -> Dict[str, Any]:
         logger.warning("Failed to load book library state for book_id=%s: %s", book_id, e)
         return _default_book_library_state(book_id)
 
-    return {
+    return _normalize_book_library_state({
         "book_id": str(book_id),
-        "is_archived": bool(state.get("is_archived", False)),
-        "updated_at": state.get("updated_at")
-        or datetime.now(timezone.utc).isoformat(),
-    }
+        "is_archived": state.get("is_archived", False),
+        "is_favorite": state.get("is_favorite", False),
+        "updated_at": state.get("updated_at"),
+    })
 
 
-def save_book_library_state(book_id: str, is_archived: bool) -> Dict[str, Any]:
+def save_book_library_state(
+    book_id: str,
+    *,
+    is_archived: bool | None = None,
+    is_favorite: bool | None = None,
+) -> Dict[str, Any]:
     relative_path = construct_storage_path(str(book_id))
-    state = {
-        "book_id": str(book_id),
-        "is_archived": bool(is_archived),
-        "updated_at": datetime.now(timezone.utc).isoformat(),
-    }
+    current_state = get_book_library_state(book_id)
+    state = _resolve_book_library_state_update(
+        current_state,
+        is_archived=is_archived,
+        is_favorite=is_favorite,
+    )
+
     write_json_file(
         file_name=BOOK_METADATA_FILENAME,
         data=state,
@@ -359,7 +417,8 @@ def save_book_library_state(book_id: str, is_archived: bool) -> Dict[str, Any]:
         metadata={
             "artifact_type": "book_metadata",
             "book_id": str(book_id),
-            "is_archived": str(bool(is_archived)).lower(),
+            "is_archived": str(state["is_archived"]).lower(),
+            "is_favorite": str(state["is_favorite"]).lower(),
         },
     )
     return state
@@ -482,9 +541,10 @@ def get_book_list() -> List[Dict[str, Any]]:
                                 e,
                             )
                         else:
-                            library_state_by_book_id[book_id] = bool(
-                                state.get("is_archived", False)
-                            )
+                            library_state_by_book_id[book_id] = {
+                                "is_archived": bool(state.get("is_archived", False)),
+                                "is_favorite": bool(state.get("is_favorite", False)),
+                            }
                         continue
 
                     if len(parts) != 2 or parts[1] != f"{parts[0]}.json":
@@ -515,16 +575,23 @@ def get_book_list() -> List[Dict[str, Any]]:
                                 "cover_url": None,
                                 "cover_expires_at": None,
                                 "images": [],
-                                "is_archived": library_state_by_book_id.get(book_id, False),
+                                "is_archived": library_state_by_book_id.get(book_id, {}).get(
+                                    "is_archived", False
+                                ),
+                                "is_favorite": library_state_by_book_id.get(book_id, {}).get(
+                                    "is_favorite", False
+                                ),
                             }
                         else:
                             # Update json_url and book_title if needed
                             books_dict[book_id]["json_url"] = json_url
                             books_dict[book_id]["book_title"] = book_title
                             books_dict[book_id]["is_archived"] = library_state_by_book_id.get(
-                                book_id,
-                                books_dict[book_id].get("is_archived", False),
-                            )
+                                book_id, {}
+                            ).get("is_archived", books_dict[book_id].get("is_archived", False))
+                            books_dict[book_id]["is_favorite"] = library_state_by_book_id.get(
+                                book_id, {}
+                            ).get("is_favorite", books_dict[book_id].get("is_favorite", False))
                     else:
                         logger.error(f"Missing metadata for blob {blob_name}")
 
@@ -544,7 +611,12 @@ def get_book_list() -> List[Dict[str, Any]]:
                                 "cover_url": cover_url,
                                 "cover_expires_at": expires_at,
                                 "images": [],
-                                "is_archived": library_state_by_book_id.get(book_id, False),
+                                "is_archived": library_state_by_book_id.get(book_id, {}).get(
+                                    "is_archived", False
+                                ),
+                                "is_favorite": library_state_by_book_id.get(book_id, {}).get(
+                                    "is_favorite", False
+                                ),
                             }
                         else:
                             books_dict[book_id]["cover_url"] = cover_url
@@ -573,7 +645,12 @@ def get_book_list() -> List[Dict[str, Any]]:
                                 "cover_url": None,
                                 "cover_expires_at": None,
                                 "images": [],
-                                "is_archived": library_state_by_book_id.get(book_id, False),
+                                "is_archived": library_state_by_book_id.get(book_id, {}).get(
+                                    "is_archived", False
+                                ),
+                                "is_favorite": library_state_by_book_id.get(book_id, {}).get(
+                                    "is_favorite", False
+                                ),
                             }
 
                         # Add image to the book's images
@@ -595,7 +672,14 @@ def get_book_list() -> List[Dict[str, Any]]:
             for book in books_list:
                 book["images"].sort(key=lambda x: x["page"])
                 book["is_archived"] = bool(
-                    library_state_by_book_id.get(book["book_id"], book.get("is_archived", False))
+                    library_state_by_book_id.get(book["book_id"], {}).get(
+                        "is_archived", book.get("is_archived", False)
+                    )
+                )
+                book["is_favorite"] = bool(
+                    library_state_by_book_id.get(book["book_id"], {}).get(
+                        "is_favorite", book.get("is_favorite", False)
+                    )
                 )
 
             return books_list
@@ -668,8 +752,10 @@ def get_book_list() -> List[Dict[str, Any]]:
                             and isinstance(page_data.get("page_number"), int)
                         ],
                         "is_archived": get_book_library_state(str(book_data["book_id"])).get(
-                            "is_archived",
-                            False,
+                            "is_archived", False
+                        ),
+                        "is_favorite": get_book_library_state(str(book_data["book_id"])).get(
+                            "is_favorite", False
                         ),
                     }
                 )
@@ -754,6 +840,7 @@ def get_book_by_id(book_id: str) -> Dict[str, Any]:
                 "cover": cover,
                 "images": images,
                 "is_archived": get_book_library_state(book_id).get("is_archived", False),
+                "is_favorite": get_book_library_state(book_id).get("is_favorite", False),
             }
         else:
             # Use local storage logic
@@ -812,6 +899,7 @@ def get_book_by_id(book_id: str) -> Dict[str, Any]:
                 "cover": cover,
                 "images": images,
                 "is_archived": get_book_library_state(book_id).get("is_archived", False),
+                "is_favorite": get_book_library_state(book_id).get("is_favorite", False),
             }
 
     except ValueError as e:

--- a/backend/tests/api/routers/test_books.py
+++ b/backend/tests/api/routers/test_books.py
@@ -69,7 +69,7 @@ async def test_create_book_non_timeout_failure_preserves_current_behavior(
 @pytest.mark.asyncio
 @patch("src.api.routers.books.get_book_by_id")
 @patch("src.api.routers.books.save_book_library_state")
-async def test_patch_archive_updates_archive_state(
+async def test_patch_library_state_updates_archive_state(
     mock_save_book_library_state,
     mock_get_book_by_id,
 ):
@@ -82,6 +82,7 @@ async def test_patch_archive_updates_archive_state(
             "cover": None,
             "images": [],
             "is_archived": False,
+            "is_favorite": False,
         },
         {
             "book_id": "book-1",
@@ -91,24 +92,102 @@ async def test_patch_archive_updates_archive_state(
             "cover": None,
             "images": [],
             "is_archived": True,
+            "is_favorite": False,
         },
     ]
 
     async with _test_client() as client:
-        response = await client.patch("/books/book-1/archive/", json={"is_archived": True})
+        response = await client.patch("/books/book-1/library-state/", json={"is_archived": True})
 
     assert response.status_code == 200
     assert response.json()["is_archived"] is True
-    mock_save_book_library_state.assert_called_once_with("book-1", True)
+    mock_save_book_library_state.assert_called_once_with("book-1", is_archived=True, is_favorite=None)
 
 
 @pytest.mark.asyncio
 @patch("src.api.routers.books.get_book_by_id")
-async def test_patch_archive_returns_404_for_missing_book(mock_get_book_by_id):
+async def test_patch_library_state_returns_404_for_missing_book(mock_get_book_by_id):
     mock_get_book_by_id.side_effect = ValueError("missing")
 
     async with _test_client() as client:
-        response = await client.patch("/books/missing/archive/", json={"is_archived": True})
+        response = await client.patch("/books/missing/library-state/", json={"is_archived": True})
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Book not found."
+
+
+@pytest.mark.asyncio
+@patch("src.api.routers.books.get_book_by_id")
+@patch("src.api.routers.books.save_book_library_state")
+async def test_patch_library_state_updates_favorite_state(
+    mock_save_book_library_state,
+    mock_get_book_by_id,
+):
+    mock_get_book_by_id.side_effect = [
+        {
+            "book_id": "book-2",
+            "book_title": "Favorite Book",
+            "json_url": "https://example.com/book-2.json",
+            "expires_at": "2026-04-02T00:00:00Z",
+            "cover": None,
+            "images": [],
+            "is_archived": False,
+            "is_favorite": False,
+        },
+        {
+            "book_id": "book-2",
+            "book_title": "Favorite Book",
+            "json_url": "https://example.com/book-2.json",
+            "expires_at": "2026-04-02T00:00:00Z",
+            "cover": None,
+            "images": [],
+            "is_archived": False,
+            "is_favorite": True,
+        },
+    ]
+
+    async with _test_client() as client:
+        response = await client.patch("/books/book-2/library-state/", json={"is_favorite": True})
+
+    assert response.status_code == 200
+    assert response.json()["is_favorite"] is True
+    mock_save_book_library_state.assert_called_once_with("book-2", is_archived=None, is_favorite=True)
+
+
+@pytest.mark.asyncio
+@patch("src.api.routers.books.get_book_by_id")
+@patch("src.api.routers.books.save_book_library_state")
+async def test_patch_library_state_restores_archived_favorite_book(
+    mock_save_book_library_state,
+    mock_get_book_by_id,
+):
+    mock_get_book_by_id.side_effect = [
+        {
+            "book_id": "book-3",
+            "book_title": "Archived Favorite Book",
+            "json_url": "https://example.com/book-3.json",
+            "expires_at": "2026-04-02T00:00:00Z",
+            "cover": None,
+            "images": [],
+            "is_archived": True,
+            "is_favorite": False,
+        },
+        {
+            "book_id": "book-3",
+            "book_title": "Archived Favorite Book",
+            "json_url": "https://example.com/book-3.json",
+            "expires_at": "2026-04-02T00:00:00Z",
+            "cover": None,
+            "images": [],
+            "is_archived": False,
+            "is_favorite": True,
+        },
+    ]
+
+    async with _test_client() as client:
+        response = await client.patch("/books/book-3/library-state/", json={"is_favorite": True})
+
+    assert response.status_code == 200
+    assert response.json()["is_archived"] is False
+    assert response.json()["is_favorite"] is True
+    mock_save_book_library_state.assert_called_once_with("book-3", is_archived=None, is_favorite=True)

--- a/backend/tests/services/test_general_utils_gcs_client.py
+++ b/backend/tests/services/test_general_utils_gcs_client.py
@@ -28,9 +28,11 @@ def test_book_library_state_defaults_and_round_trips_locally(tmp_path, monkeypat
 
     default_state = general_utils.get_book_library_state("book-local-1")
     assert default_state["is_archived"] is False
+    assert default_state["is_favorite"] is False
 
-    saved_state = general_utils.save_book_library_state("book-local-1", True)
+    saved_state = general_utils.save_book_library_state("book-local-1", is_archived=True)
     assert saved_state["is_archived"] is True
+    assert saved_state["is_favorite"] is False
 
     metadata_path = (
         tmp_path / "local_data" / "book-local-1" / general_utils.BOOK_METADATA_FILENAME
@@ -39,4 +41,78 @@ def test_book_library_state_defaults_and_round_trips_locally(tmp_path, monkeypat
 
     persisted_payload = json.loads(metadata_path.read_text(encoding="utf-8"))
     assert persisted_payload["is_archived"] is True
+    assert persisted_payload["is_favorite"] is False
     assert general_utils.get_book_library_state("book-local-1")["is_archived"] is True
+
+
+def test_book_library_state_normalizes_archive_and_favorite_invariants(tmp_path, monkeypatch):
+    monkeypatch.setattr(general_utils.settings, "use_cloud_storage", False)
+    monkeypatch.setattr(general_utils.settings, "local_data_path", str(tmp_path / "local_data"))
+
+    favorited_state = general_utils.save_book_library_state(
+        "book-local-2",
+        is_favorite=True,
+    )
+    assert favorited_state["is_favorite"] is True
+    assert favorited_state["is_archived"] is False
+
+    archived_state = general_utils.save_book_library_state(
+        "book-local-2",
+        is_archived=True,
+    )
+    assert archived_state["is_archived"] is True
+    assert archived_state["is_favorite"] is False
+
+    restored_favorite_state = general_utils.save_book_library_state(
+        "book-local-2",
+        is_favorite=True,
+    )
+    assert restored_favorite_state["is_favorite"] is True
+    assert restored_favorite_state["is_archived"] is False
+
+    unfavorited_state = general_utils.save_book_library_state(
+        "book-local-2",
+        is_favorite=False,
+    )
+    assert unfavorited_state["is_favorite"] is False
+    assert unfavorited_state["is_archived"] is False
+
+    rearchived_state = general_utils.save_book_library_state(
+        "book-local-2",
+        is_archived=True,
+    )
+    assert rearchived_state["is_archived"] is True
+    assert rearchived_state["is_favorite"] is False
+
+    restored_from_archive_state = general_utils.save_book_library_state(
+        "book-local-2",
+        is_favorite=True,
+    )
+    assert restored_from_archive_state["is_favorite"] is True
+    assert restored_from_archive_state["is_archived"] is False
+
+
+def test_book_library_state_normalizes_legacy_inconsistent_metadata_on_read(tmp_path, monkeypatch):
+    monkeypatch.setattr(general_utils.settings, "use_cloud_storage", False)
+    monkeypatch.setattr(general_utils.settings, "local_data_path", str(tmp_path / "local_data"))
+
+    metadata_path = (
+        tmp_path / "local_data" / "book-local-3" / general_utils.BOOK_METADATA_FILENAME
+    )
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "book_id": "book-local-3",
+                "is_archived": True,
+                "is_favorite": True,
+                "updated_at": "2026-04-07T12:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    normalized_state = general_utils.get_book_library_state("book-local-3")
+
+    assert normalized_state["is_archived"] is True
+    assert normalized_state["is_favorite"] is False

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -36,6 +36,16 @@ const areBookIdListsEqual = (left = [], right = []) =>
 
 const SHELF_COVER_WARM_CONCURRENCY = 2;
 
+const normalizeLibraryFlags = (bookData = {}) => {
+  const isArchived = Boolean(bookData.is_archived);
+  const isFavorite = isArchived ? false : Boolean(bookData.is_favorite);
+
+  return {
+    is_archived: isArchived,
+    is_favorite: isFavorite,
+  };
+};
+
 const normalizeBook = (bookData = {}) => ({
   ...bookData,
   book_id: bookData.book_id,
@@ -53,8 +63,29 @@ const normalizeBook = (bookData = {}) => ({
     bookData.cover_source_kind ??
     (bookData.cover_url ?? bookData.remote_cover_url ?? bookData.cover?.url ? "remote" : "none"),
   images: bookData.images ?? [],
-  is_archived: Boolean(bookData.is_archived),
+  ...normalizeLibraryFlags(bookData),
 });
+
+const applyLibraryStateRules = (bookData = {}, updates = {}) => {
+  const nextBook = {
+    ...bookData,
+    ...normalizeLibraryFlags(bookData),
+    ...(updates.is_archived !== undefined ? { is_archived: Boolean(updates.is_archived) } : {}),
+    ...(updates.is_favorite !== undefined ? { is_favorite: Boolean(updates.is_favorite) } : {}),
+  };
+
+  if (updates.is_archived === true) {
+    nextBook.is_favorite = false;
+  } else if (updates.is_favorite === true) {
+    nextBook.is_archived = false;
+  } else if (nextBook.is_archived) {
+    nextBook.is_favorite = false;
+  } else if (nextBook.is_favorite) {
+    nextBook.is_archived = false;
+  }
+
+  return nextBook;
+};
 
 const mergeShelfCoverUrls = (books, coverMap) => {
   let changed = false;
@@ -111,7 +142,7 @@ const App = () => {
   const [libraryLoading, setLibraryLoading] = useState(false);
   const [libraryError, setLibraryError] = useState(false);
   const [activeFullBookWorkCount, setActiveFullBookWorkCount] = useState(0);
-  const [archiveActionBookIds, setArchiveActionBookIds] = useState([]);
+  const [pendingLibraryStateBookIds, setPendingLibraryStateBookIds] = useState([]);
   const [, setVisibleBookIds] = useState([]);
   const libraryFetchPromiseRef = useRef(null);
   const cachedBookObjectUrlsRef = useRef([]);
@@ -271,6 +302,7 @@ const App = () => {
       cover_url: data.cover?.url ?? data.cover_url ?? null,
       images: data.images ?? bookData.images ?? [],
       is_archived: Boolean(data.is_archived ?? bookData.is_archived),
+      is_favorite: Boolean(data.is_favorite ?? bookData.is_favorite),
     };
   };
 
@@ -496,6 +528,7 @@ const App = () => {
           ...bookData,
           cover_url: data.cover?.url ?? data.cover_url ?? null,
           is_archived: Boolean(data.is_archived ?? bookData.is_archived),
+          is_favorite: Boolean(data.is_favorite ?? bookData.is_favorite),
         });
 
         openBook(completeBookData);
@@ -517,39 +550,40 @@ const App = () => {
     setBook(null);
   };
 
-  const handleToggleArchive = async (bookId, isArchived) => {
+  const handleUpdateLibraryState = async (bookId, updates) => {
     if (!bookId) {
       return;
     }
 
-    setArchiveActionBookIds((current) =>
+    setPendingLibraryStateBookIds((current) =>
       current.includes(bookId) ? current : [...current, bookId],
     );
 
     const previousBook = libraryBooks.find((entry) => entry.book_id === bookId) ?? null;
+    const optimisticBook = previousBook ? normalizeBook(applyLibraryStateRules(previousBook, updates)) : null;
 
     setLibraryBooks((currentBooks) =>
       sortBooksByTitle(
         currentBooks.map((entry) =>
-          entry.book_id === bookId ? { ...entry, is_archived: isArchived } : entry,
+          entry.book_id === bookId ? normalizeBook(applyLibraryStateRules(entry, updates)) : entry,
         ),
       ),
     );
     setBook((currentBook) =>
       currentBook?.book_id === bookId
-        ? { ...currentBook, is_archived: isArchived }
+        ? normalizeBook(applyLibraryStateRules(currentBook, updates))
         : currentBook,
     );
 
     try {
-      const response = await fetch(buildApiUrl(`/books/${bookId}/archive/`), {
+      const response = await fetch(buildApiUrl(`/books/${bookId}/library-state/`), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ is_archived: isArchived }),
+        body: JSON.stringify(updates),
       });
 
       if (!response.ok) {
-        throw new Error(`Failed to update archive state. status=${response.status}`);
+        throw new Error(`Failed to update library state. status=${response.status}`);
       }
 
       const updatedBook = normalizeBook(await response.json());
@@ -561,12 +595,12 @@ const App = () => {
         ),
       );
       setBook((currentBook) =>
-        currentBook?.book_id === bookId
-          ? { ...currentBook, ...updatedBook }
-          : currentBook,
+          currentBook?.book_id === bookId
+            ? { ...currentBook, ...updatedBook }
+            : currentBook,
       );
     } catch (error) {
-      console.error(`Failed to update archive state for book ${bookId}:`, error);
+      console.error(`Failed to update library state for book ${bookId}:`, error);
       if (previousBook) {
         setLibraryBooks((currentBooks) =>
           sortBooksByTitle(
@@ -580,10 +614,16 @@ const App = () => {
             ? { ...currentBook, ...previousBook }
             : currentBook,
         );
+      } else if (optimisticBook) {
+        setBook((currentBook) =>
+          currentBook?.book_id === bookId
+            ? { ...currentBook, ...optimisticBook }
+            : currentBook,
+        );
       }
-      alert("Error updating archive state. Please try again.");
+      alert("Error updating library state. Please try again.");
     } finally {
-      setArchiveActionBookIds((current) => current.filter((entry) => entry !== bookId));
+      setPendingLibraryStateBookIds((current) => current.filter((entry) => entry !== bookId));
     }
   };
 
@@ -664,8 +704,8 @@ const App = () => {
         onRetry={() => fetchLibraryBooks({ force: true })}
         onSelectBook={handleSelectBook}
         onVisibleBooksChange={handleVisibleBooksChange}
-        onToggleArchive={handleToggleArchive}
-        archiveActionBookIds={archiveActionBookIds}
+        onUpdateLibraryState={handleUpdateLibraryState}
+        pendingLibraryStateBookIds={pendingLibraryStateBookIds}
       />
 
       {isModalOpen && book && (

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -722,6 +722,7 @@ test("archives a shelf book and moves it to the archive tab", async () => {
           book_id: "book-archive-1",
           book_title: "Archive Candidate",
           is_archived: false,
+          is_favorite: true,
         },
       ],
     })
@@ -731,6 +732,7 @@ test("archives a shelf book and moves it to the archive tab", async () => {
         book_id: "book-archive-1",
         book_title: "Archive Candidate",
         is_archived: true,
+        is_favorite: false,
         json_url: "https://example.com/book-archive-1.json",
         images: [],
       }),
@@ -751,7 +753,7 @@ test("archives a shelf book and moves it to the archive tab", async () => {
   });
 
   await waitFor(() => {
-    expect(global.fetch).toHaveBeenLastCalledWith("http://localhost/books/book-archive-1/archive/", {
+    expect(global.fetch).toHaveBeenLastCalledWith("http://localhost/books/book-archive-1/library-state/", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ is_archived: true }),
@@ -763,4 +765,186 @@ test("archives a shelf book and moves it to the archive tab", async () => {
   });
 
   expect(await screen.findByRole("button", { name: exactName("Archive Candidate") })).toBeInTheDocument();
+});
+
+test("favorites a shelf book and shows it in the favorites tab", async () => {
+  global.fetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          book_id: "book-favorite-1",
+          book_title: "Favorite Candidate",
+          is_archived: false,
+          is_favorite: false,
+        },
+      ],
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        book_id: "book-favorite-1",
+        book_title: "Favorite Candidate",
+        is_archived: false,
+        is_favorite: true,
+        json_url: "https://example.com/book-favorite-1.json",
+        images: [],
+      }),
+    });
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  await act(async () => {
+    fireEvent.click(await screen.findByRole("button", {
+      name: /more actions for favorite candidate/i,
+    }));
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /add to favorites/i }));
+  });
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenLastCalledWith("http://localhost/books/book-favorite-1/library-state/", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ is_favorite: true }),
+    });
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("tab", { name: /favorites/i }));
+  });
+
+  expect(await screen.findByRole("button", { name: exactName("Favorite Candidate") })).toBeInTheDocument();
+});
+
+test("favoriting an archived book restores it to shelf and favorites", async () => {
+  global.fetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          book_id: "book-favorite-archive-1",
+          book_title: "Archived Favorite Candidate",
+          is_archived: true,
+          is_favorite: false,
+        },
+      ],
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        book_id: "book-favorite-archive-1",
+        book_title: "Archived Favorite Candidate",
+        is_archived: false,
+        is_favorite: true,
+        json_url: "https://example.com/book-favorite-archive-1.json",
+        images: [],
+      }),
+    });
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("tab", { name: /archive/i }));
+  });
+
+  await act(async () => {
+    fireEvent.click(await screen.findByRole("button", {
+      name: /more actions for archived favorite candidate/i,
+    }));
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /add to favorites/i }));
+  });
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      "http://localhost/books/book-favorite-archive-1/library-state/",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_favorite: true }),
+      },
+    );
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("tab", { name: /book shelf/i }));
+  });
+
+  expect(await screen.findByRole("button", { name: exactName("Archived Favorite Candidate") })).toBeInTheDocument();
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("tab", { name: /favorites/i }));
+  });
+
+  expect(await screen.findByRole("button", { name: exactName("Archived Favorite Candidate") })).toBeInTheDocument();
+});
+
+test("favoriting an archived book with stale favorite state removes it from archive immediately", async () => {
+  const patchRequest = createDeferred();
+
+  global.fetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          book_id: "book-stale-archive-favorite-1",
+          book_title: "Stale Archived Favorite Candidate",
+          is_archived: true,
+          is_favorite: true,
+        },
+      ],
+    })
+    .mockReturnValueOnce(patchRequest.promise);
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("tab", { name: /archive/i }));
+  });
+
+  expect(await screen.findByRole("button", { name: exactName("Stale Archived Favorite Candidate") })).toBeInTheDocument();
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", {
+      name: /more actions for stale archived favorite candidate/i,
+    }));
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /add to favorites/i }));
+  });
+
+  expect(screen.queryByRole("button", { name: exactName("Stale Archived Favorite Candidate") })).not.toBeInTheDocument();
+  expect(screen.getByText("Archive is empty")).toBeInTheDocument();
+
+  await act(async () => {
+    patchRequest.resolve({
+      ok: true,
+      json: async () => ({
+        book_id: "book-stale-archive-favorite-1",
+        book_title: "Stale Archived Favorite Candidate",
+        is_archived: false,
+        is_favorite: true,
+        json_url: "https://example.com/book-stale-archive-favorite-1.json",
+        images: [],
+      }),
+    });
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("tab", { name: /favorites/i }));
+  });
+
+  expect(await screen.findByRole("button", { name: exactName("Stale Archived Favorite Candidate") })).toBeInTheDocument();
 });

--- a/frontend/src/components/BookList.js
+++ b/frontend/src/components/BookList.js
@@ -4,6 +4,7 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { getImageDebugPageContext, logImageEvent } from "../debug/imageDebug";
 
 const BOOK_SHELF_TAB = "bookshelf";
+const FAVORITES_TAB = "favorites";
 const ARCHIVE_TAB = "archive";
 const TAB_WIDTH = 152;
 const TAB_BAR_SIDE_PADDING = 18;
@@ -11,6 +12,7 @@ const TAB_HEIGHT = 52;
 const TAB_BAR_OVERLAP = 8;
 const ACTIVE_TAB_BRIDGE_HEIGHT = 12;
 const MOBILE_GRID_MEDIA_QUERY = "(max-width: 600px)";
+const CARD_CORNER_RADIUS = 14;
 
 const usePrefersReducedMotion = () => {
   const getPreference = () =>
@@ -168,8 +170,8 @@ const BookList = ({
   onRetry,
   onSelectBook,
   onVisibleBooksChange,
-  onToggleArchive = () => {},
-  archiveActionBookIds = [],
+  onUpdateLibraryState = () => {},
+  pendingLibraryStateBookIds = [],
 }) => {
   const buttonRefs = useRef({});
   const cardInnerRefs = useRef({});
@@ -179,10 +181,18 @@ const BookList = ({
   const [flippedBookId, setFlippedBookId] = useState(null);
   const prefersReducedMotion = usePrefersReducedMotion();
   const isMobileGrid = useIsMobileGrid();
-  const pendingArchiveBookIds = new Set(archiveActionBookIds);
-  const visibleBooks = books.filter((book) =>
-    activeTab === BOOK_SHELF_TAB ? !book.is_archived : book.is_archived,
-  );
+  const pendingStateBookIds = new Set(pendingLibraryStateBookIds);
+  const visibleBooks = books.filter((book) => {
+    if (activeTab === BOOK_SHELF_TAB) {
+      return !book.is_archived;
+    }
+
+    if (activeTab === FAVORITES_TAB) {
+      return Boolean(book.is_favorite) && !book.is_archived;
+    }
+
+    return book.is_archived;
+  });
 
   useLayoutEffect(() => {
     if (visibleBooks.length === 0) {
@@ -373,7 +383,56 @@ const BookList = ({
   const handleArchiveAction = (event, book) => {
     event.stopPropagation();
     setFlippedBookId(null);
-    onToggleArchive(book.book_id, !book.is_archived);
+    onUpdateLibraryState(book.book_id, { is_archived: !book.is_archived });
+  };
+
+  const handleFavoriteAction = (event, book) => {
+    event.stopPropagation();
+    setFlippedBookId(null);
+    const isEffectiveFavorite = Boolean(book.is_favorite) && !book.is_archived;
+    onUpdateLibraryState(book.book_id, { is_favorite: !isEffectiveFavorite });
+  };
+
+  const getTabStyleSet = (tab) => {
+    if (tab === FAVORITES_TAB) {
+      return {
+        tabButton: styles.favoritesTabButton,
+        content: styles.favoritesContent,
+        bridge: styles.favoritesActiveTabBridge,
+        bookButton: styles.favoritesBookButton,
+        frontActionButton: styles.favoritesFrontActionButton,
+        bookTitle: styles.favoritesBookTitle,
+        cardBack: styles.favoritesCardBack,
+        backTitle: styles.favoritesBackTitle,
+        backActionButton: styles.favoritesBackActionButton,
+      };
+    }
+
+    if (tab === ARCHIVE_TAB) {
+      return {
+        tabButton: styles.archiveTabButton,
+        content: styles.archiveContent,
+        bridge: styles.archiveActiveTabBridge,
+        bookButton: styles.archiveBookButton,
+        frontActionButton: styles.archiveFrontActionButton,
+        bookTitle: styles.archiveBookTitle,
+        cardBack: styles.archiveCardBack,
+        backTitle: styles.archiveBackTitle,
+        backActionButton: styles.archiveBackActionButton,
+      };
+    }
+
+    return {
+      tabButton: null,
+      content: null,
+      bridge: null,
+      bookButton: null,
+      frontActionButton: null,
+      bookTitle: null,
+      cardBack: null,
+      backTitle: null,
+      backActionButton: null,
+    };
   };
 
   const renderContent = () => {
@@ -398,9 +457,14 @@ const BookList = ({
           style={{
             ...styles.message,
             ...(activeTab === ARCHIVE_TAB ? styles.archiveMessage : {}),
+            ...(activeTab === FAVORITES_TAB ? styles.favoritesMessage : {}),
           }}
         >
-          {activeTab === ARCHIVE_TAB ? "Archive is empty" : "Book Shelf is empty"}
+          {activeTab === ARCHIVE_TAB
+            ? "Archive is empty"
+            : activeTab === FAVORITES_TAB
+              ? "You don't have any Favorites yet."
+              : "Book Shelf is empty"}
         </p>
       );
     }
@@ -413,6 +477,12 @@ const BookList = ({
         }}
       >
         {visibleBooks.map((book) => (
+          (() => {
+            const tabStyleSet = getTabStyleSet(activeTab);
+            const isPending = pendingStateBookIds.has(book.book_id);
+            const isEffectiveFavorite = Boolean(book.is_favorite) && !book.is_archived;
+
+            return (
           <li
             key={book.book_id}
             style={styles.listItem}
@@ -474,7 +544,7 @@ const BookList = ({
                     aria-label={book.book_title}
                     style={{
                       ...styles.bookButton,
-                      ...(activeTab === ARCHIVE_TAB ? styles.archiveBookButton : {}),
+                      ...(tabStyleSet.bookButton ?? {}),
                     }}
                     onClick={() => {
                       onSelectBook(book.book_id);
@@ -483,7 +553,7 @@ const BookList = ({
                     <span
                       style={{
                         ...styles.bookTitle,
-                        ...(activeTab === ARCHIVE_TAB ? styles.archiveBookTitle : {}),
+                        ...(tabStyleSet.bookTitle ?? {}),
                       }}
                     >
                       {book.book_title}
@@ -503,7 +573,7 @@ const BookList = ({
                     aria-label={`More actions for ${book.book_title}`}
                     style={{
                       ...styles.frontActionButton,
-                      ...(activeTab === ARCHIVE_TAB ? styles.archiveFrontActionButton : {}),
+                      ...(tabStyleSet.frontActionButton ?? {}),
                     }}
                     onClick={(event) => handleFlipToggle(event, book.book_id)}
                   >
@@ -515,7 +585,7 @@ const BookList = ({
                   style={{
                     ...styles.cardFace,
                     ...styles.cardBack,
-                    ...(activeTab === ARCHIVE_TAB ? styles.archiveCardBack : {}),
+                    ...(tabStyleSet.cardBack ?? {}),
                     ...(prefersReducedMotion ? styles.cardBackReducedMotion : {}),
                     ...(prefersReducedMotion
                       ? flippedBookId === book.book_id
@@ -529,7 +599,7 @@ const BookList = ({
                     aria-label={`Return to cover for ${book.book_title}`}
                     style={{
                       ...styles.backActionButton,
-                      ...(activeTab === ARCHIVE_TAB ? styles.archiveBackActionButton : {}),
+                      ...(tabStyleSet.backActionButton ?? {}),
                     }}
                     onClick={(event) => handleFlipToggle(event, book.book_id)}
                   >
@@ -539,31 +609,47 @@ const BookList = ({
                     <p
                       style={{
                         ...styles.backTitle,
-                        ...(activeTab === ARCHIVE_TAB ? styles.archiveBackTitle : {}),
+                        ...(tabStyleSet.backTitle ?? {}),
                       }}
                     >
                       {book.book_title}
                     </p>
-                    <button
-                      type="button"
-                      style={{
-                        ...styles.menuActionButton,
-                        ...(activeTab === ARCHIVE_TAB ? styles.archiveMenuActionButton : {}),
-                      }}
-                      disabled={pendingArchiveBookIds.has(book.book_id)}
-                      onClick={(event) => handleArchiveAction(event, book)}
-                    >
-                      {pendingArchiveBookIds.has(book.book_id)
-                        ? "Saving..."
-                        : book.is_archived
-                          ? "Restore to Book Shelf"
-                          : "Move to Archive"}
-                    </button>
+                    <div style={styles.backActions}>
+                      <button
+                        type="button"
+                        style={{
+                          ...styles.menuActionButton,
+                          ...(activeTab === ARCHIVE_TAB ? styles.archiveMenuActionButton : {}),
+                        }}
+                        disabled={isPending}
+                        onClick={(event) => handleArchiveAction(event, book)}
+                      >
+                        {isPending
+                          ? "Saving..."
+                          : book.is_archived
+                            ? "Restore to Book Shelf"
+                            : "Move to Archive"}
+                      </button>
+                      <button
+                        type="button"
+                        style={styles.favoritesMenuActionButton}
+                        disabled={isPending}
+                        onClick={(event) => handleFavoriteAction(event, book)}
+                      >
+                        {isPending
+                          ? "Saving..."
+                          : isEffectiveFavorite
+                            ? "Remove from Favorites"
+                            : "Add to Favorites"}
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </li>
+            );
+          })()
         ))}
       </ul>
     );
@@ -588,6 +674,21 @@ const BookList = ({
         <button
           type="button"
           role="tab"
+          aria-selected={activeTab === FAVORITES_TAB}
+          onClick={() => setActiveTab(FAVORITES_TAB)}
+          style={{
+            ...styles.tabButton,
+            ...styles.favoritesTabButton,
+            ...styles.trailingTabButton,
+            ...(activeTab !== FAVORITES_TAB ? styles.inactiveTabButton : {}),
+            ...(activeTab === FAVORITES_TAB ? styles.activeTabButton : {}),
+          }}
+        >
+          <span style={styles.tabLabel}>Favorites</span>
+        </button>
+        <button
+          type="button"
+          role="tab"
           aria-selected={activeTab === ARCHIVE_TAB}
           onClick={() => setActiveTab(ARCHIVE_TAB)}
           style={{
@@ -605,18 +706,20 @@ const BookList = ({
           data-testid="active-tab-bridge"
           style={{
             ...styles.activeTabBridge,
-            ...(activeTab === ARCHIVE_TAB ? styles.archiveActiveTabBridge : {}),
+            ...(getTabStyleSet(activeTab).bridge ?? {}),
             left:
               activeTab === BOOK_SHELF_TAB
                 ? TAB_BAR_SIDE_PADDING
-                : TAB_BAR_SIDE_PADDING + TAB_WIDTH,
+                : activeTab === FAVORITES_TAB
+                  ? TAB_BAR_SIDE_PADDING + (TAB_WIDTH - 10)
+                  : TAB_BAR_SIDE_PADDING + ((TAB_WIDTH - 10) * 2),
           }}
         />
       </div>
       <div
         style={{
           ...styles.content,
-          ...(activeTab === ARCHIVE_TAB ? styles.archiveContent : {}),
+          ...(getTabStyleSet(activeTab).content ?? {}),
         }}
       >
         {renderContent()}
@@ -680,6 +783,10 @@ const styles = {
     backgroundColor: "#FFCC00",
     color: "#CA054D",
   },
+  favoritesTabButton: {
+    backgroundColor: "#36839b",
+    color: "#FFCC00",
+  },
   inactiveTabButton: {
     zIndex: 1,
     filter: "brightness(0.96)",
@@ -701,6 +808,9 @@ const styles = {
   archiveActiveTabBridge: {
     backgroundColor: "#FFCC00",
   },
+  favoritesActiveTabBridge: {
+    backgroundColor: "#36839b",
+  },
   content: {
     minHeight: "48px",
     backgroundColor: "#CA054D",
@@ -716,6 +826,10 @@ const styles = {
   archiveContent: {
     backgroundColor: "#FFCC00",
     color: "#CA054D",
+  },
+  favoritesContent: {
+    backgroundColor: "#36839b",
+    color: "#FFCC00",
   },
   list: {
     display: 'grid',
@@ -735,6 +849,8 @@ const styles = {
     position: "relative",
     width: "100%",
     perspective: "1200px",
+    borderRadius: `${CARD_CORNER_RADIUS}px`,
+    overflow: "hidden",
   },
   cardReducedMotion: {
     perspective: "none",
@@ -744,6 +860,7 @@ const styles = {
     width: "100%",
     transformStyle: "preserve-3d",
     transition: "transform 320ms cubic-bezier(0.22, 1, 0.36, 1)",
+    borderRadius: `${CARD_CORNER_RADIUS}px`,
   },
   cardInnerFlipped: {
     transform: "rotateY(180deg)",
@@ -755,7 +872,8 @@ const styles = {
     width: "100%",
     boxSizing: "border-box",
     backfaceVisibility: "hidden",
-    borderRadius: "14px",
+    borderRadius: `${CARD_CORNER_RADIUS}px`,
+    overflow: "hidden",
   },
   visibleFaceReducedMotion: {
     opacity: 1,
@@ -784,7 +902,7 @@ const styles = {
     padding: "16px 16px 24px 24px",
     backgroundColor: "#FFCC00",
     border: "none",
-    borderRadius: "8px",
+    borderRadius: `${CARD_CORNER_RADIUS}px`,
     cursor: "pointer",
     transition: "background-color 0.2s",
     textAlign: "center",
@@ -794,6 +912,9 @@ const styles = {
     outline: "none",
   },
   archiveBookButton: {
+    backgroundColor: "#36839b",
+  },
+  favoritesBookButton: {
     backgroundColor: "#CA054D",
   },
   frontActionButton: {
@@ -818,6 +939,10 @@ const styles = {
     backgroundColor: "rgba(255, 204, 0, 0.2)",
     color: "#FFCC00",
   },
+  favoritesFrontActionButton: {
+    backgroundColor: "rgba(255, 204, 0, 0.2)",
+    color: "#FFCC00",
+  },
   bookTitle: {
     fontSize: "20px",
     color: "#CA054D",
@@ -827,6 +952,9 @@ const styles = {
     flexShrink: 0,
   },
   archiveBookTitle: {
+    color: "#FFCC00",
+  },
+  favoritesBookTitle: {
     color: "#FFCC00",
   },
   coverSlot: {
@@ -867,7 +995,10 @@ const styles = {
     justifyContent: "center",
   },
   archiveCardBack: {
-    background: "linear-gradient(160deg, rgba(202, 5, 77, 0.98), rgba(138, 0, 51, 0.98))",
+    background: "linear-gradient(160deg, rgba(125, 182, 199, 0.98), rgba(82, 156, 179, 0.98))",
+  },
+  favoritesCardBack: {
+    background: "linear-gradient(160deg, rgba(234, 122, 160, 0.98), rgba(214, 78, 126, 0.98))",
   },
   cardBackReducedMotion: {
     transform: "none",
@@ -879,6 +1010,13 @@ const styles = {
     gap: "18px",
     width: "100%",
   },
+  backActions: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "12px",
+    width: "100%",
+    alignItems: "center",
+  },
   backTitle: {
     margin: 0,
     color: "#8A0033",
@@ -887,6 +1025,9 @@ const styles = {
     textAlign: "center",
   },
   archiveBackTitle: {
+    color: "#FFCC00",
+  },
+  favoritesBackTitle: {
     color: "#FFCC00",
   },
   backActionButton: {
@@ -908,6 +1049,10 @@ const styles = {
     backgroundColor: "#FFCC00",
     color: "#CA054D",
   },
+  favoritesBackActionButton: {
+    backgroundColor: "#FFCC00",
+    color: "#36839b",
+  },
   menuActionButton: {
     width: "100%",
     maxWidth: "220px",
@@ -924,6 +1069,18 @@ const styles = {
     backgroundColor: "#FFCC00",
     color: "#CA054D",
   },
+  favoritesMenuActionButton: {
+    width: "100%",
+    maxWidth: "220px",
+    border: "none",
+    borderRadius: "14px",
+    padding: "14px 18px",
+    backgroundColor: "#36839b",
+    color: "#FFCC00",
+    fontSize: "15px",
+    fontWeight: "700",
+    cursor: "pointer",
+  },
   materialSymbol: {
     fontFamily: '"Material Symbols Outlined"',
     fontSize: "22px",
@@ -938,6 +1095,9 @@ const styles = {
   },
   archiveMessage: {
     color: "#CA054D",
+  },
+  favoritesMessage: {
+    color: "#FFCC00",
   },
   feedbackPanel: {
     display: "flex",

--- a/frontend/src/components/BookList.test.js
+++ b/frontend/src/components/BookList.test.js
@@ -74,7 +74,7 @@ const baseProps = {
   error: false,
   onRetry: jest.fn(),
   onSelectBook: jest.fn(),
-  onToggleArchive: jest.fn(),
+  onUpdateLibraryState: jest.fn(),
 };
 
 const renderBookList = (books) =>
@@ -105,11 +105,12 @@ describe("BookList", () => {
     ]);
 
     expect(screen.getByRole("tab", { name: /book shelf/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: /favorites/i })).toHaveAttribute("aria-selected", "false");
     expect(screen.getByRole("tab", { name: /archive/i })).toHaveAttribute("aria-selected", "false");
     expect(screen.getByRole("button", { name: exactName("Default Shelf Book") })).toBeInTheDocument();
   });
 
-  test("uses a shared label wrapper and consistent tab height for both tabs", () => {
+  test("uses a shared label wrapper and consistent tab height for all tabs", () => {
     renderBookList([
       {
         book_id: "book-shared-label",
@@ -119,19 +120,26 @@ describe("BookList", () => {
     ]);
 
     const shelfTab = screen.getByRole("tab", { name: /book shelf/i });
+    const favoritesTab = screen.getByRole("tab", { name: /favorites/i });
     const archiveTab = screen.getByRole("tab", { name: /archive/i });
     const shelfLabel = shelfTab.querySelector("span");
+    const favoritesLabel = favoritesTab.querySelector("span");
     const archiveLabel = archiveTab.querySelector("span");
 
     expect(shelfLabel.tagName).toBe("SPAN");
+    expect(favoritesLabel.tagName).toBe("SPAN");
     expect(archiveLabel.tagName).toBe("SPAN");
     expect(shelfTab).toContainElement(shelfLabel);
+    expect(favoritesTab).toContainElement(favoritesLabel);
     expect(archiveTab).toContainElement(archiveLabel);
     expect(shelfTab).toHaveStyle({ display: "flex", alignItems: "center", justifyContent: "center" });
+    expect(favoritesTab).toHaveStyle({ display: "flex", alignItems: "center", justifyContent: "center" });
     expect(archiveTab).toHaveStyle({ display: "flex", alignItems: "center", justifyContent: "center" });
     expect(shelfTab.style.height).toBe("52px");
+    expect(favoritesTab.style.height).toBe("52px");
     expect(archiveTab.style.height).toBe("52px");
     expect(shelfLabel).toHaveStyle({ minHeight: "100%" });
+    expect(favoritesLabel).toHaveStyle({ minHeight: "100%" });
     expect(archiveLabel).toHaveStyle({ minHeight: "100%" });
   });
 
@@ -146,14 +154,18 @@ describe("BookList", () => {
 
     const bridge = screen.getByTestId("active-tab-bridge");
     const shelfTab = screen.getByRole("tab", { name: /book shelf/i });
+    const favoritesTab = screen.getByRole("tab", { name: /favorites/i });
     const archiveTab = screen.getByRole("tab", { name: /archive/i });
 
     expect(bridge).toHaveStyle({ bottom: "-8px", height: "12px" });
     expect(shelfTab.style.transform).toBe("");
+    expect(favoritesTab.style.transform).toBe("");
     expect(archiveTab.style.transform).toBe("");
     expect(shelfTab.style.top).toBe("");
+    expect(favoritesTab.style.top).toBe("");
     expect(archiveTab.style.top).toBe("");
     expect(shelfTab.querySelector("span")).not.toHaveStyle({ transform: expect.any(String) });
+    expect(favoritesTab.querySelector("span")).not.toHaveStyle({ transform: expect.any(String) });
     expect(archiveTab.querySelector("span")).not.toHaveStyle({ transform: expect.any(String) });
   });
 
@@ -279,7 +291,7 @@ describe("BookList", () => {
     fireEvent.click(screen.getByRole("tab", { name: /archive/i }));
 
     const button = screen.getByRole("button", { name: exactName("Archived Colors") });
-    expect(button).toHaveStyle({ backgroundColor: "#CA054D" });
+    expect(button).toHaveStyle({ backgroundColor: "#36839b" });
     expect(within(button).getByText("Archived Colors")).toHaveStyle({ color: "#FFCC00" });
   });
 
@@ -327,7 +339,7 @@ describe("BookList", () => {
 
   test("archives from the card action without selecting the book", () => {
     const onSelectBook = jest.fn();
-    const onToggleArchive = jest.fn();
+    const onUpdateLibraryState = jest.fn();
 
     render(
       <BookList
@@ -340,15 +352,72 @@ describe("BookList", () => {
           },
         ]}
         onSelectBook={onSelectBook}
-        onToggleArchive={onToggleArchive}
+        onUpdateLibraryState={onUpdateLibraryState}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /more actions for archive me/i }));
     fireEvent.click(screen.getByRole("button", { name: /move to archive/i }));
 
-    expect(onToggleArchive).toHaveBeenCalledWith("book-archive", true);
+    expect(onUpdateLibraryState).toHaveBeenCalledWith("book-archive", { is_archived: true });
     expect(onSelectBook).not.toHaveBeenCalled();
+  });
+
+  test("favorites from the card action without selecting the book", () => {
+    const onSelectBook = jest.fn();
+    const onUpdateLibraryState = jest.fn();
+
+    render(
+      <BookList
+        {...baseProps}
+        books={[
+          {
+            book_id: "book-favorite",
+            book_title: "Favorite Me",
+            is_archived: false,
+            is_favorite: false,
+          },
+        ]}
+        onSelectBook={onSelectBook}
+        onUpdateLibraryState={onUpdateLibraryState}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /more actions for favorite me/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add to favorites/i }));
+
+    expect(onUpdateLibraryState).toHaveBeenCalledWith("book-favorite", { is_favorite: true });
+    expect(onSelectBook).not.toHaveBeenCalled();
+  });
+
+  test("favoriting an archived stale favorite state still sends add-to-favorites", () => {
+    const onUpdateLibraryState = jest.fn();
+
+    render(
+      <BookList
+        {...baseProps}
+        books={[
+          {
+            book_id: "book-archive-favorite-stale",
+            book_title: "Archived Stale Favorite",
+            is_archived: true,
+            is_favorite: true,
+          },
+        ]}
+        onUpdateLibraryState={onUpdateLibraryState}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: /archive/i }));
+    fireEvent.click(screen.getByRole("button", { name: /more actions for archived stale favorite/i }));
+
+    expect(screen.getByRole("button", { name: /add to favorites/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /add to favorites/i }));
+
+    expect(onUpdateLibraryState).toHaveBeenCalledWith("book-archive-favorite-stale", {
+      is_favorite: true,
+    });
   });
 
   test("flips a card open and closed without opening the book", () => {
@@ -418,7 +487,7 @@ describe("BookList", () => {
     expect(screen.getByRole("button", { name: /return to cover for second book/i })).toBeInTheDocument();
   });
 
-  test("switches to Archive and back to Book Shelf", () => {
+  test("switches across Book Shelf, Favorites, and Archive", () => {
     matchMediaController.setMatches(mobileGridQuery, true);
 
     renderBookList([
@@ -426,31 +495,53 @@ describe("BookList", () => {
         book_id: "book-6",
         book_title: "Archive Toggle Book",
         is_archived: false,
+        is_favorite: false,
+      },
+      {
+        book_id: "book-6b",
+        book_title: "Favorite Shelf Book",
+        is_archived: false,
+        is_favorite: true,
       },
       {
         book_id: "book-7",
         book_title: "Archived Book",
         is_archived: true,
+        is_favorite: true,
       },
     ]);
 
     expect(screen.getByRole("list")).toHaveStyle({ gridTemplateColumns: "1fr" });
+
+    fireEvent.click(screen.getByRole("tab", { name: /favorites/i }));
+
+    expect(screen.getByRole("tab", { name: /favorites/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("button", { name: exactName("Favorite Shelf Book") })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: exactName("Archive Toggle Book") })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: exactName("Archived Book") })).not.toBeInTheDocument();
+    const favoriteFrontButton = screen.getByRole("button", { name: exactName("Favorite Shelf Book") });
+    expect(favoriteFrontButton).toHaveStyle({
+      backgroundColor: "#CA054D",
+    });
+    expect(within(favoriteFrontButton).getByText("Favorite Shelf Book")).toHaveStyle({ color: "#FFCC00" });
 
     fireEvent.click(screen.getByRole("tab", { name: /archive/i }));
 
     expect(screen.getByRole("tab", { name: /archive/i })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("button", { name: exactName("Archived Book") })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: exactName("Archive Toggle Book") })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: exactName("Favorite Shelf Book") })).not.toBeInTheDocument();
     expect(screen.getByRole("list")).toHaveStyle({ gridTemplateColumns: "1fr" });
     const archivedFrontButton = screen.getByRole("button", { name: exactName("Archived Book") });
     expect(archivedFrontButton).toHaveStyle({
-      backgroundColor: "#CA054D",
+      backgroundColor: "#36839b",
     });
     expect(within(archivedFrontButton).getByText("Archived Book")).toHaveStyle({ color: "#FFCC00" });
 
     fireEvent.click(screen.getByRole("button", { name: /more actions for archived book/i }));
     expect(screen.getByRole("button", { name: /restore to book shelf/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /restore to book shelf/i }).previousSibling).toHaveStyle({
+    expect(screen.getByRole("button", { name: /add to favorites/i })).toBeInTheDocument();
+    expect(screen.getAllByText("Archived Book")[1]).toHaveStyle({
       color: "#FFCC00",
     });
     expect(screen.getByRole("button", { name: /return to cover for archived book/i })).toHaveStyle({
@@ -466,12 +557,14 @@ describe("BookList", () => {
 
     expect(screen.getByRole("tab", { name: /book shelf/i })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("button", { name: exactName("Archive Toggle Book") })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: exactName("Favorite Shelf Book") })).toBeInTheDocument();
   });
 
   test("renders loading state inline with tabs visible", () => {
     render(<BookList {...baseProps} books={[]} loading />);
 
     expect(screen.getByRole("tab", { name: /book shelf/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /favorites/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /archive/i })).toBeInTheDocument();
     expect(screen.getByText("Loading books...")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /close modal/i })).not.toBeInTheDocument();
@@ -483,12 +576,28 @@ describe("BookList", () => {
     render(<BookList {...baseProps} books={[]} error onRetry={onRetry} />);
 
     expect(screen.getByRole("tab", { name: /book shelf/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /favorites/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /archive/i })).toBeInTheDocument();
     expect(screen.getByText("Error fetching books. Please try again later.")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /retry/i }));
 
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  test("shows the favorites empty state text", () => {
+    renderBookList([
+      {
+        book_id: "book-non-favorite",
+        book_title: "Not Favorite",
+        is_archived: false,
+        is_favorite: false,
+      },
+    ]);
+
+    fireEvent.click(screen.getByRole("tab", { name: /favorites/i }));
+
+    expect(screen.getByText("You don't have any Favorites yet.")).toBeInTheDocument();
   });
 
   test("equalizes card heights within each desktop row only", async () => {


### PR DESCRIPTION
Added a new Favorites tab between Book Shelf and Archive, backed by a persisted is_favorite book state on the backend and surfaced through the existing library/book APIs. Users can now add or remove favorites from the back of any book card, favorite books appear in both Book Shelf and Favorites, and archiving a book removes it from favorites automatically while favoriting an archived book restores it to Book Shelf.

On the frontend, the tabbed library UI now supports the new Favorites view, state transitions are handled optimistically, and the card-back actions mirror the existing archive interaction. On the backend, library-state persistence was generalized beyond archive-only handling so is_archived and is_favorite are stored and normalized together. Added targeted frontend and backend test coverage for the new tab, favorite/archive transitions, and persisted library-state behavior.