### PR TITLE
Add book shelf/favorite/archive sorting by title and creation date

### DIFF
--- a/backend/src/api/models/book_models.py
+++ b/backend/src/api/models/book_models.py
@@ -196,6 +196,7 @@ class CoverResponse(BaseModel):
 class BookResponse(BaseModel):
     book_id: str
     book_title: str
+    created_at: Optional[datetime] = None
     expires_at: datetime  # Expiration timestamp for the JSON URL
     json_url: str  # Pre-signed URL for the book's JSON metadata
     cover: Optional[CoverResponse] = None

--- a/backend/src/api/routers/books.py
+++ b/backend/src/api/routers/books.py
@@ -89,6 +89,7 @@ async def create_book(book_request: BookCreateRequest):
         response = BookResponse(
             book_id=str(book.book_id),
             book_title=book.book_title,
+            created_at=datetime.now(timezone.utc),
             expires_at=expires_at,
             json_url=json_url,
             is_archived=False,

--- a/backend/src/utils/general_utils.py
+++ b/backend/src/utils/general_utils.py
@@ -51,6 +51,49 @@ _GCS_CLIENT_LOCK = threading.Lock()
 BOOK_METADATA_FILENAME = "metadata.json"
 
 
+def _serialize_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+
+    return value.isoformat()
+
+
+def _get_blob_created_at(blob) -> str | None:
+    try:
+        created_at = getattr(blob, "time_created", None)
+        if created_at is None:
+            return None
+        return _serialize_datetime(created_at)
+    except Exception as e:
+        logger.warning(
+            "Failed to serialize blob created_at for blob=%s: %s",
+            getattr(blob, "name", None),
+            e,
+        )
+        return None
+
+
+def _get_path_created_at(path: Path) -> str | None:
+    try:
+        stat_result = path.stat()
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        logger.warning("Failed to read created_at for path=%s: %s", path, e)
+        return None
+
+    try:
+        created_at = datetime.fromtimestamp(stat_result.st_mtime, tz=timezone.utc)
+    except Exception as e:
+        logger.warning("Failed to parse created_at for path=%s: %s", path, e)
+        return None
+
+    return _serialize_datetime(created_at)
+
+
 def get_project_root() -> Path:
     """
     Determines the project root by navigating up the directory tree until it finds
@@ -555,6 +598,7 @@ def get_book_list() -> List[Dict[str, Any]]:
                     metadata = blob.metadata or {}
                     if metadata.get("artifact_type") not in {None, "book_json"}:
                         continue
+                    created_at = _get_blob_created_at(blob)
                     book_id = metadata.get("book_id")
                     book_title = metadata.get("book_title")
                     logger.debug(
@@ -570,6 +614,7 @@ def get_book_list() -> List[Dict[str, Any]]:
                             books_dict[book_id] = {
                                 "book_id": book_id,
                                 "book_title": book_title,
+                                "created_at": created_at,
                                 "json_url": json_url,
                                 "expires_at": expires_at,
                                 "cover_url": None,
@@ -586,6 +631,7 @@ def get_book_list() -> List[Dict[str, Any]]:
                             # Update json_url and book_title if needed
                             books_dict[book_id]["json_url"] = json_url
                             books_dict[book_id]["book_title"] = book_title
+                            books_dict[book_id]["created_at"] = created_at
                             books_dict[book_id]["is_archived"] = library_state_by_book_id.get(
                                 book_id, {}
                             ).get("is_archived", books_dict[book_id].get("is_archived", False))
@@ -606,6 +652,7 @@ def get_book_list() -> List[Dict[str, Any]]:
                             books_dict[book_id] = {
                                 "book_id": book_id,
                                 "book_title": "",
+                                "created_at": None,
                                 "json_url": "",
                                 "expires_at": expires_at,
                                 "cover_url": cover_url,
@@ -640,6 +687,7 @@ def get_book_list() -> List[Dict[str, Any]]:
                             books_dict[book_id] = {
                                 "book_id": book_id,
                                 "book_title": "",  # Will be updated when JSON is processed
+                                "created_at": None,
                                 "json_url": "",  # Will be updated when JSON is processed
                                 "expires_at": expires_at,
                                 "cover_url": None,
@@ -729,6 +777,7 @@ def get_book_list() -> List[Dict[str, Any]]:
                     {
                         "book_id": str(book_data["book_id"]),
                         "book_title": book_data["book_title"],
+                        "created_at": _get_path_created_at(book_json_path),
                         "json_url": str(book_json_path.resolve()),
                         "expires_at": datetime.now(timezone.utc) + expiration_time,
                         "cover_url": (
@@ -805,6 +854,7 @@ def get_book_by_id(book_id: str) -> Dict[str, Any]:
             book_blob.reload()
             metadata = book_blob.metadata or {}
             book_title = metadata.get("book_title", "Unknown Title")
+            created_at = _get_blob_created_at(book_blob)
             logger.debug(
                 f"get_book_by_id(): `book_blob` reloaded. `metadata` set. `book_title` set."
             )
@@ -835,6 +885,7 @@ def get_book_by_id(book_id: str) -> Dict[str, Any]:
             return {
                 "book_id": book_id,
                 "book_title": book_title,
+                "created_at": created_at,
                 "json_url": json_url,
                 "expires_at": expires_at,
                 "cover": cover,
@@ -894,6 +945,7 @@ def get_book_by_id(book_id: str) -> Dict[str, Any]:
             return {
                 "book_id": book_id,
                 "book_title": book_title,
+                "created_at": _get_path_created_at(book_json_path),
                 "json_url": str(book_json_path.resolve()),  # Local path
                 "expires_at": expires_at,
                 "cover": cover,

--- a/backend/tests/api/models/test_books.py
+++ b/backend/tests/api/models/test_books.py
@@ -39,6 +39,7 @@ async def test_create_book(mock_generate_book):
     assert response.status_code == 200
     data = response.json()
     assert data["book_title"] == "The Adventures of Testy McTestface"
+    assert "created_at" in data
     assert len(data["images"]) == 2
     assert data["images"][0]["page"] == 1
     assert data["images"][0]["url"] == "http://example.com/image1.png"

--- a/backend/tests/api/routers/test_books.py
+++ b/backend/tests/api/routers/test_books.py
@@ -15,6 +15,52 @@ def _test_client() -> AsyncClient:
 
 
 @pytest.mark.asyncio
+@patch("src.api.routers.books.get_book_list")
+async def test_list_books_includes_created_at(mock_get_book_list):
+    mock_get_book_list.return_value = [
+        {
+            "book_id": "book-list-1",
+            "book_title": "List Book",
+            "created_at": "2026-04-02T00:00:00Z",
+            "json_url": "https://example.com/book-list-1.json",
+            "expires_at": "2026-04-02T00:00:00Z",
+            "cover": None,
+            "images": [],
+            "is_archived": False,
+            "is_favorite": False,
+        }
+    ]
+
+    async with _test_client() as client:
+        response = await client.get("/books/")
+
+    assert response.status_code == 200
+    assert response.json()[0]["created_at"] == "2026-04-02T00:00:00Z"
+
+
+@pytest.mark.asyncio
+@patch("src.api.routers.books.get_book_by_id")
+async def test_fetch_book_by_id_includes_created_at(mock_get_book_by_id):
+    mock_get_book_by_id.return_value = {
+        "book_id": "book-detail-1",
+        "book_title": "Detail Book",
+        "created_at": "2026-04-02T00:00:00Z",
+        "json_url": "https://example.com/book-detail-1.json",
+        "expires_at": "2026-04-02T00:00:00Z",
+        "cover": None,
+        "images": [],
+        "is_archived": False,
+        "is_favorite": False,
+    }
+
+    async with _test_client() as client:
+        response = await client.get("/books/book-detail-1/")
+
+    assert response.status_code == 200
+    assert response.json()["created_at"] == "2026-04-02T00:00:00Z"
+
+
+@pytest.mark.asyncio
 @patch("src.api.routers.books.content_generation.generate_book")
 async def test_create_book_story_timeout_returns_504(mock_generate_book):
     mock_generate_book.side_effect = StoryGenerationTimeoutError(
@@ -77,6 +123,7 @@ async def test_patch_library_state_updates_archive_state(
         {
             "book_id": "book-1",
             "book_title": "Archive Book",
+            "created_at": "2026-04-02T00:00:00Z",
             "json_url": "https://example.com/book-1.json",
             "expires_at": "2026-04-02T00:00:00Z",
             "cover": None,
@@ -87,6 +134,7 @@ async def test_patch_library_state_updates_archive_state(
         {
             "book_id": "book-1",
             "book_title": "Archive Book",
+            "created_at": "2026-04-02T00:00:00Z",
             "json_url": "https://example.com/book-1.json",
             "expires_at": "2026-04-02T00:00:00Z",
             "cover": None,
@@ -101,6 +149,7 @@ async def test_patch_library_state_updates_archive_state(
 
     assert response.status_code == 200
     assert response.json()["is_archived"] is True
+    assert response.json()["created_at"] == "2026-04-02T00:00:00Z"
     mock_save_book_library_state.assert_called_once_with("book-1", is_archived=True, is_favorite=None)
 
 
@@ -127,6 +176,7 @@ async def test_patch_library_state_updates_favorite_state(
         {
             "book_id": "book-2",
             "book_title": "Favorite Book",
+            "created_at": "2026-04-02T00:00:00Z",
             "json_url": "https://example.com/book-2.json",
             "expires_at": "2026-04-02T00:00:00Z",
             "cover": None,
@@ -137,6 +187,7 @@ async def test_patch_library_state_updates_favorite_state(
         {
             "book_id": "book-2",
             "book_title": "Favorite Book",
+            "created_at": "2026-04-02T00:00:00Z",
             "json_url": "https://example.com/book-2.json",
             "expires_at": "2026-04-02T00:00:00Z",
             "cover": None,
@@ -151,6 +202,7 @@ async def test_patch_library_state_updates_favorite_state(
 
     assert response.status_code == 200
     assert response.json()["is_favorite"] is True
+    assert response.json()["created_at"] == "2026-04-02T00:00:00Z"
     mock_save_book_library_state.assert_called_once_with("book-2", is_archived=None, is_favorite=True)
 
 
@@ -165,6 +217,7 @@ async def test_patch_library_state_restores_archived_favorite_book(
         {
             "book_id": "book-3",
             "book_title": "Archived Favorite Book",
+            "created_at": "2026-04-02T00:00:00Z",
             "json_url": "https://example.com/book-3.json",
             "expires_at": "2026-04-02T00:00:00Z",
             "cover": None,
@@ -175,6 +228,7 @@ async def test_patch_library_state_restores_archived_favorite_book(
         {
             "book_id": "book-3",
             "book_title": "Archived Favorite Book",
+            "created_at": "2026-04-02T00:00:00Z",
             "json_url": "https://example.com/book-3.json",
             "expires_at": "2026-04-02T00:00:00Z",
             "cover": None,
@@ -190,4 +244,5 @@ async def test_patch_library_state_restores_archived_favorite_book(
     assert response.status_code == 200
     assert response.json()["is_archived"] is False
     assert response.json()["is_favorite"] is True
+    assert response.json()["created_at"] == "2026-04-02T00:00:00Z"
     mock_save_book_library_state.assert_called_once_with("book-3", is_archived=None, is_favorite=True)

--- a/backend/tests/services/test_general_utils_gcs_client.py
+++ b/backend/tests/services/test_general_utils_gcs_client.py
@@ -2,6 +2,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 from pathlib import Path
 import json
+from datetime import datetime, timezone
+import os
 
 from src.utils import general_utils
 
@@ -116,3 +118,29 @@ def test_book_library_state_normalizes_legacy_inconsistent_metadata_on_read(tmp_
 
     assert normalized_state["is_archived"] is True
     assert normalized_state["is_favorite"] is False
+
+
+def test_get_book_by_id_returns_local_created_at(tmp_path, monkeypatch):
+    monkeypatch.setattr(general_utils.settings, "use_cloud_storage", False)
+    monkeypatch.setattr(general_utils.settings, "local_data_path", str(tmp_path / "local_data"))
+
+    book_dir = tmp_path / "local_data" / "book-local-created"
+    book_dir.mkdir(parents=True, exist_ok=True)
+    book_json_path = book_dir / "book-local-created.json"
+    book_json_path.write_text(
+        json.dumps(
+            {
+                "book_id": "book-local-created",
+                "book_title": "Created Locally",
+                "pages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    created_at = datetime(2026, 4, 9, 12, 0, tzinfo=timezone.utc).timestamp()
+    os.utime(book_json_path, (created_at, created_at))
+
+    book = general_utils.get_book_by_id("book-local-created")
+
+    assert book["created_at"] == "2026-04-09T12:00:00+00:00"

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,7 +15,6 @@ import {
   saveShelfMetadata,
 } from "./cache/libraryCache";
 import { getImageDebugPageContext, logImageEvent } from "./debug/imageDebug";
-
 const releaseObjectUrls = (urls = []) => {
   if (typeof URL?.revokeObjectURL !== "function") {
     return;
@@ -27,9 +26,6 @@ const releaseObjectUrls = (urls = []) => {
     }
   });
 };
-
-const sortBooksByTitle = (books = []) =>
-  [...books].sort((left, right) => left.book_title.localeCompare(right.book_title));
 
 const areBookIdListsEqual = (left = [], right = []) =>
   left.length === right.length && left.every((value, index) => value === right[index]);
@@ -50,6 +46,7 @@ const normalizeBook = (bookData = {}) => ({
   ...bookData,
   book_id: bookData.book_id,
   book_title: bookData.book_title,
+  created_at: bookData.created_at ?? null,
   json_url: bookData.json_url,
   remote_cover_url: bookData.remote_cover_url ?? bookData.cover_url ?? bookData.cover?.url ?? null,
   remote_cover_expires_at:
@@ -209,10 +206,10 @@ const App = () => {
       if (existingIndex >= 0) {
         const nextBooks = [...previousBooks];
         nextBooks[existingIndex] = { ...nextBooks[existingIndex], ...normalizedBook };
-        return sortBooksByTitle(nextBooks);
+        return nextBooks;
       }
 
-      return sortBooksByTitle([normalizedBook, ...previousBooks]);
+      return [normalizedBook, ...previousBooks];
     });
   };
 
@@ -239,9 +236,7 @@ const App = () => {
         }
 
         const books = await response.json();
-        const normalizedBooks = Array.isArray(books)
-          ? sortBooksByTitle(books.map((entry) => normalizeBook(entry)))
-          : [];
+        const normalizedBooks = Array.isArray(books) ? books.map((entry) => normalizeBook(entry)) : [];
         setLibraryBooks(normalizedBooks);
         await Promise.all(
           normalizedBooks.map((bookEntry) => {
@@ -310,7 +305,7 @@ const App = () => {
     logImageEvent("app:mount", getImageDebugPageContext());
     const cachedMetadata = loadShelfMetadataSync();
     if (cachedMetadata?.books?.length) {
-      setLibraryBooks(sortBooksByTitle(cachedMetadata.books.map((entry) => normalizeBook(entry))));
+      setLibraryBooks(cachedMetadata.books.map((entry) => normalizeBook(entry)));
       logImageEvent("shelf:metadata_hydrated", {
         count: cachedMetadata.books.length,
       });
@@ -563,10 +558,8 @@ const App = () => {
     const optimisticBook = previousBook ? normalizeBook(applyLibraryStateRules(previousBook, updates)) : null;
 
     setLibraryBooks((currentBooks) =>
-      sortBooksByTitle(
-        currentBooks.map((entry) =>
-          entry.book_id === bookId ? normalizeBook(applyLibraryStateRules(entry, updates)) : entry,
-        ),
+      currentBooks.map((entry) =>
+        entry.book_id === bookId ? normalizeBook(applyLibraryStateRules(entry, updates)) : entry,
       ),
     );
     setBook((currentBook) =>
@@ -588,11 +581,7 @@ const App = () => {
 
       const updatedBook = normalizeBook(await response.json());
       setLibraryBooks((currentBooks) =>
-        sortBooksByTitle(
-          currentBooks.map((entry) =>
-            entry.book_id === bookId ? { ...entry, ...updatedBook } : entry,
-          ),
-        ),
+        currentBooks.map((entry) => (entry.book_id === bookId ? { ...entry, ...updatedBook } : entry)),
       );
       setBook((currentBook) =>
           currentBook?.book_id === bookId
@@ -603,11 +592,7 @@ const App = () => {
       console.error(`Failed to update library state for book ${bookId}:`, error);
       if (previousBook) {
         setLibraryBooks((currentBooks) =>
-          sortBooksByTitle(
-            currentBooks.map((entry) =>
-              entry.book_id === bookId ? { ...entry, ...previousBook } : entry,
-            ),
-          ),
+          currentBooks.map((entry) => (entry.book_id === bookId ? { ...entry, ...previousBook } : entry)),
         );
         setBook((currentBook) =>
           currentBook?.book_id === bookId

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -111,6 +111,7 @@ test("renders cached shelf metadata before the background refresh resolves", asy
         {
           book_id: "cached-book-1",
           book_title: "Cached Shelf Book",
+          created_at: "2026-04-08T10:00:00Z",
           cover_url: "https://example.com/cached-cover.png",
           is_archived: false,
         },
@@ -140,6 +141,7 @@ test("renders cached shelf metadata before the background refresh resolves", asy
         {
           book_id: "remote-book-1",
           book_title: "Remote Shelf Book",
+          created_at: "2026-04-09T10:00:00Z",
           is_archived: false,
         },
       ],
@@ -338,6 +340,7 @@ test("clears the theme after a successful generation", async () => {
       json: async () => ({
         book_id: "generated-book-1",
         book_title: "Generated Book",
+        created_at: "2026-04-09T12:00:00Z",
         json_url: "https://example.com/generated-book-1.json",
         cover: {
           url: "https://example.com/generated-book-1-cover.png",
@@ -382,6 +385,63 @@ test("clears the theme after a successful generation", async () => {
 
   await screen.findByRole("button", { name: /close modal/i });
   expect(themeInput).toHaveValue("");
+
+  await waitFor(() => {
+    expect(mockSaveFullBookPackage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        book_id: "generated-book-1",
+        created_at: "2026-04-09T12:00:00Z",
+      }),
+    );
+  });
+});
+
+test("preserves created_at when hydrating and refreshing shelf metadata", async () => {
+  window.localStorage.setItem(
+    "kwento_shelf_metadata_v1",
+    JSON.stringify({
+      version: 1,
+      books: [
+        {
+          book_id: "created-cache-book",
+          book_title: "Created Cache Book",
+          created_at: "2026-04-07T10:00:00Z",
+          is_archived: false,
+        },
+      ],
+      updatedAt: Date.now(),
+      expiresAt: Date.now() + 1000,
+    }),
+  );
+
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => [
+      {
+        book_id: "created-cache-book",
+        book_title: "Created Cache Book",
+        created_at: "2026-04-08T10:00:00Z",
+        is_archived: false,
+      },
+    ],
+  });
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  expect(screen.getByRole("button", { name: exactName("Created Cache Book") })).toBeInTheDocument();
+
+  await waitFor(() => {
+    expect(mockSaveShelfMetadata).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          book_id: "created-cache-book",
+          created_at: "2026-04-08T10:00:00Z",
+        }),
+      ]),
+    );
+  });
 });
 
 test("clears the theme after a failed generation request", async () => {

--- a/frontend/src/components/BookList.js
+++ b/frontend/src/components/BookList.js
@@ -2,10 +2,17 @@
 
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { getImageDebugPageContext, logImageEvent } from "../debug/imageDebug";
-
-const BOOK_SHELF_TAB = "bookshelf";
-const FAVORITES_TAB = "favorites";
-const ARCHIVE_TAB = "archive";
+import {
+  ARCHIVE_TAB,
+  BOOK_SHELF_TAB,
+  DEFAULT_SORTS_BY_TAB,
+  FAVORITES_TAB,
+  SORT_FIELDS,
+  cycleSort,
+  getSortIcon,
+  isSortActive,
+  sortBooks,
+} from "../utils/bookSorting";
 const TAB_WIDTH = 152;
 const TAB_BAR_SIDE_PADDING = 18;
 const TAB_HEIGHT = 52;
@@ -182,21 +189,26 @@ const BookList = ({
   const itemRefs = useRef({});
   const [layoutVersion, setLayoutVersion] = useState(0);
   const [activeTab, setActiveTab] = useState(BOOK_SHELF_TAB);
+  const [sortsByTab, setSortsByTab] = useState(() => ({ ...DEFAULT_SORTS_BY_TAB }));
   const [flippedBookId, setFlippedBookId] = useState(null);
   const prefersReducedMotion = usePrefersReducedMotion();
   const isMobileGrid = useIsMobileGrid();
   const pendingStateBookIds = new Set(pendingLibraryStateBookIds);
-  const visibleBooks = books.filter((book) => {
-    if (activeTab === BOOK_SHELF_TAB) {
-      return !book.is_archived;
-    }
+  const currentSort = sortsByTab[activeTab] ?? DEFAULT_SORTS_BY_TAB[activeTab];
+  const visibleBooks = sortBooks(
+    books.filter((book) => {
+      if (activeTab === BOOK_SHELF_TAB) {
+        return !book.is_archived;
+      }
 
-    if (activeTab === FAVORITES_TAB) {
-      return Boolean(book.is_favorite) && !book.is_archived;
-    }
+      if (activeTab === FAVORITES_TAB) {
+        return Boolean(book.is_favorite) && !book.is_archived;
+      }
 
-    return book.is_archived;
-  });
+      return book.is_archived;
+    }),
+    currentSort,
+  );
 
   useLayoutEffect(() => {
     if (visibleBooks.length === 0) {
@@ -379,6 +391,13 @@ const BookList = ({
     setLayoutVersion((currentVersion) => currentVersion + 1);
   };
 
+  const handleSortToggle = (field) => {
+    setSortsByTab((currentSortsByTab) => ({
+      ...currentSortsByTab,
+      [activeTab]: cycleSort(currentSortsByTab[activeTab], field),
+    }));
+  };
+
   const handleFlipToggle = (event, bookId) => {
     event.stopPropagation();
     setFlippedBookId((currentId) => (currentId === bookId ? null : bookId));
@@ -436,6 +455,27 @@ const BookList = ({
       cardBack: null,
       backTitle: null,
       backActionButton: null,
+    };
+  };
+
+  const getSortPalette = (tab) => {
+    if (tab === ARCHIVE_TAB) {
+      return {
+        segment: styles.archiveSortSegment,
+        active: styles.archiveSortSegmentActive,
+      };
+    }
+
+    if (tab === FAVORITES_TAB) {
+      return {
+        segment: styles.favoritesSortSegment,
+        active: styles.favoritesSortSegmentActive,
+      };
+    }
+
+    return {
+      segment: null,
+      active: null,
     };
   };
 
@@ -740,6 +780,43 @@ const BookList = ({
           ...(getTabStyleSet(activeTab).content ?? {}),
         }}
       >
+        <div
+          style={{
+            ...styles.sortBar,
+            ...(isMobileGrid ? styles.mobileSortBar : {}),
+          }}
+          role="group"
+          aria-label="Sort books"
+        >
+          <button
+            type="button"
+            aria-pressed={isSortActive(currentSort, SORT_FIELDS.TITLE)}
+            style={{
+              ...styles.sortSegment,
+              ...(getSortPalette(activeTab).segment ?? {}),
+              ...(isSortActive(currentSort, SORT_FIELDS.TITLE) ? styles.sortSegmentActive : {}),
+              ...(isSortActive(currentSort, SORT_FIELDS.TITLE) ? (getSortPalette(activeTab).active ?? {}) : {}),
+            }}
+            onClick={() => handleSortToggle(SORT_FIELDS.TITLE)}
+          >
+            <span style={styles.sortSegmentLabel}>Title</span>
+            <span style={styles.materialSymbol}>{getSortIcon(currentSort, SORT_FIELDS.TITLE)}</span>
+          </button>
+          <button
+            type="button"
+            aria-pressed={isSortActive(currentSort, SORT_FIELDS.CREATED)}
+            style={{
+              ...styles.sortSegment,
+              ...(getSortPalette(activeTab).segment ?? {}),
+              ...(isSortActive(currentSort, SORT_FIELDS.CREATED) ? styles.sortSegmentActive : {}),
+              ...(isSortActive(currentSort, SORT_FIELDS.CREATED) ? (getSortPalette(activeTab).active ?? {}) : {}),
+            }}
+            onClick={() => handleSortToggle(SORT_FIELDS.CREATED)}
+          >
+            <span style={styles.sortSegmentLabel}>Created</span>
+            <span style={styles.materialSymbol}>{getSortIcon(currentSort, SORT_FIELDS.CREATED)}</span>
+          </button>
+        </div>
         {renderContent()}
       </div>
     </div>
@@ -850,6 +927,61 @@ const styles = {
     boxSizing: "border-box",
     boxShadow:
       "0 18px 28px -16px rgba(0, 0, 0, 0.24), 0 10px 16px -12px rgba(0, 0, 0, 0.16)",
+  },
+  sortBar: {
+    display: "flex",
+    gap: "12px",
+    marginBottom: "20px",
+  },
+  mobileSortBar: {
+    gap: "10px",
+  },
+  sortSegment: {
+    flex: "1 1 0",
+    minWidth: 0,
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: "rgba(255, 252, 240, 0.32)",
+    borderRadius: "14px",
+    padding: "12px 14px",
+    backgroundColor: "rgba(255, 252, 240, 0.12)",
+    color: "#FFFCF0",
+    cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: "8px",
+    fontSize: "15px",
+    fontWeight: "700",
+  },
+  sortSegmentActive: {
+    backgroundColor: "#FFCC00",
+    color: "#8A0033",
+    borderColor: "#FFCC00",
+  },
+  archiveSortSegment: {
+    backgroundColor: "rgba(202, 5, 77, 0.08)",
+    color: "#8A0033",
+    borderColor: "rgba(202, 5, 77, 0.2)",
+  },
+  archiveSortSegmentActive: {
+    backgroundColor: "#36839b",
+    color: "#FFCC00",
+    borderColor: "#36839b",
+  },
+  favoritesSortSegment: {
+    backgroundColor: "rgba(255, 252, 240, 0.14)",
+    color: "#FFFCF0",
+    borderColor: "rgba(255, 252, 240, 0.3)",
+  },
+  favoritesSortSegmentActive: {
+    backgroundColor: "#FFCC00",
+    color: "#36839b",
+    borderColor: "#FFCC00",
+  },
+  sortSegmentLabel: {
+    minWidth: 0,
+    whiteSpace: "nowrap",
   },
   archiveContent: {
     backgroundColor: "#FFCC00",

--- a/frontend/src/components/BookList.test.js
+++ b/frontend/src/components/BookList.test.js
@@ -84,6 +84,9 @@ const exactName = (label) => new RegExp(`^${label}$`, "i");
 const mobileGridQuery = "(max-width: 600px)";
 let matchMediaController;
 
+const getRenderedBookTitles = () =>
+  screen.getAllByRole("listitem").map((item) => item.querySelector('button[aria-label]')?.getAttribute("aria-label"));
+
 describe("BookList", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -108,6 +111,25 @@ describe("BookList", () => {
     expect(screen.getByRole("tab", { name: /favorites/i })).toHaveAttribute("aria-selected", "false");
     expect(screen.getByRole("tab", { name: /archive/i })).toHaveAttribute("aria-selected", "false");
     expect(screen.getByRole("button", { name: exactName("Default Shelf Book") })).toBeInTheDocument();
+  });
+
+  test("shows title sorting as active by default", () => {
+    renderBookList([
+      {
+        book_id: "book-b",
+        book_title: "Bravo",
+        is_archived: false,
+      },
+      {
+        book_id: "book-a",
+        book_title: "Alpha",
+        is_archived: false,
+      },
+    ]);
+
+    expect(screen.getByRole("button", { name: /title/i })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /created/i })).toHaveAttribute("aria-pressed", "false");
+    expect(getRenderedBookTitles()).toEqual(["Alpha", "Bravo"]);
   });
 
   test("uses a shared label wrapper and consistent tab height for all tabs", () => {
@@ -280,6 +302,23 @@ describe("BookList", () => {
     expect(list).toHaveStyle({ gridTemplateColumns: "1fr" });
   });
 
+  test("keeps the sort controls inline on mobile", () => {
+    matchMediaController.setMatches(mobileGridQuery, true);
+
+    renderBookList([
+      {
+        book_id: "mobile-sort-book-1",
+        book_title: "Mobile Sort Book 1",
+        is_archived: false,
+      },
+    ]);
+
+    const sortGroup = screen.getByRole("group", { name: /sort books/i });
+    expect(sortGroup).toHaveStyle({ display: "flex" });
+    expect(screen.getByRole("button", { name: /title/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /created/i })).toBeInTheDocument();
+  });
+
   test("updates the grid when the mobile media query changes", () => {
     renderBookList([
       {
@@ -406,6 +445,116 @@ describe("BookList", () => {
     fireEvent.click(screen.getByRole("button", { name: exactName("Clickable Cover") }));
 
     expect(onSelectBook).toHaveBeenCalledWith("book-5");
+  });
+
+  test("cycles title sorting between ascending and descending", () => {
+    renderBookList([
+      {
+        book_id: "book-2",
+        book_title: "Bravo",
+        is_archived: false,
+      },
+      {
+        book_id: "book-1",
+        book_title: "Alpha",
+        is_archived: false,
+      },
+    ]);
+
+    const titleSortButton = screen.getByRole("button", { name: /title/i });
+
+    expect(getRenderedBookTitles()).toEqual(["Alpha", "Bravo"]);
+
+    fireEvent.click(titleSortButton);
+    expect(getRenderedBookTitles()).toEqual(["Bravo", "Alpha"]);
+
+    fireEvent.click(titleSortButton);
+    expect(getRenderedBookTitles()).toEqual(["Alpha", "Bravo"]);
+  });
+
+  test("cycles created sorting and returns to the default title sort", () => {
+    renderBookList([
+      {
+        book_id: "book-2",
+        book_title: "Beta",
+        created_at: "2026-04-09T10:00:00Z",
+        is_archived: false,
+      },
+      {
+        book_id: "book-1",
+        book_title: "Alpha",
+        created_at: "2026-04-08T10:00:00Z",
+        is_archived: false,
+      },
+      {
+        book_id: "book-3",
+        book_title: "Gamma",
+        created_at: "2026-04-10T10:00:00Z",
+        is_archived: false,
+      },
+    ]);
+
+    const createdSortButton = screen.getByRole("button", { name: /created/i });
+    const titleSortButton = screen.getByRole("button", { name: /title/i });
+
+    fireEvent.click(createdSortButton);
+    expect(createdSortButton).toHaveAttribute("aria-pressed", "true");
+    expect(titleSortButton).toHaveAttribute("aria-pressed", "false");
+    expect(getRenderedBookTitles()).toEqual(["Alpha", "Beta", "Gamma"]);
+
+    fireEvent.click(createdSortButton);
+    expect(getRenderedBookTitles()).toEqual(["Gamma", "Beta", "Alpha"]);
+
+    fireEvent.click(createdSortButton);
+    expect(titleSortButton).toHaveAttribute("aria-pressed", "true");
+    expect(createdSortButton).toHaveAttribute("aria-pressed", "false");
+    expect(getRenderedBookTitles()).toEqual(["Alpha", "Beta", "Gamma"]);
+  });
+
+  test("retains sort state independently for each tab during the session", () => {
+    renderBookList([
+      {
+        book_id: "shelf-1",
+        book_title: "Shelf Alpha",
+        created_at: "2026-04-08T10:00:00Z",
+        is_archived: false,
+        is_favorite: false,
+      },
+      {
+        book_id: "shelf-2",
+        book_title: "Shelf Beta",
+        created_at: "2026-04-09T10:00:00Z",
+        is_archived: false,
+        is_favorite: true,
+      },
+      {
+        book_id: "archive-1",
+        book_title: "Archive Older",
+        created_at: "2026-04-07T10:00:00Z",
+        is_archived: true,
+      },
+      {
+        book_id: "archive-2",
+        book_title: "Archive Newer",
+        created_at: "2026-04-10T10:00:00Z",
+        is_archived: true,
+      },
+    ]);
+
+    const createdSortButton = screen.getByRole("button", { name: /created/i });
+
+    fireEvent.click(createdSortButton);
+    fireEvent.click(createdSortButton);
+    expect(getRenderedBookTitles()).toEqual(["Shelf Beta", "Shelf Alpha"]);
+
+    fireEvent.click(screen.getByRole("tab", { name: /archive/i }));
+    expect(getRenderedBookTitles()).toEqual(["Archive Newer", "Archive Older"]);
+
+    fireEvent.click(createdSortButton);
+    expect(getRenderedBookTitles()).toEqual(["Archive Older", "Archive Newer"]);
+
+    fireEvent.click(screen.getByRole("tab", { name: /book shelf/i }));
+    expect(getRenderedBookTitles()).toEqual(["Shelf Beta", "Shelf Alpha"]);
   });
 
   test("archives from the card action without selecting the book", () => {

--- a/frontend/src/utils/bookSorting.js
+++ b/frontend/src/utils/bookSorting.js
@@ -1,0 +1,146 @@
+const TITLE_SORT_FIELD = "title";
+const CREATED_SORT_FIELD = "created";
+
+export const BOOK_SHELF_TAB = "bookshelf";
+export const FAVORITES_TAB = "favorites";
+export const ARCHIVE_TAB = "archive";
+
+export const DEFAULT_SORT = {
+  field: TITLE_SORT_FIELD,
+  direction: "asc",
+};
+
+export const DEFAULT_SORTS_BY_TAB = {
+  [BOOK_SHELF_TAB]: DEFAULT_SORT,
+  [FAVORITES_TAB]: DEFAULT_SORT,
+  [ARCHIVE_TAB]: DEFAULT_SORT,
+};
+
+const titleCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base",
+  ignorePunctuation: true,
+});
+
+const normalizeDirection = (direction) => (direction === "desc" ? "desc" : "asc");
+
+const normalizeSort = (sort) => {
+  if (!sort?.field) {
+    return DEFAULT_SORT;
+  }
+
+  return {
+    field: sort.field,
+    direction: normalizeDirection(sort.direction),
+  };
+};
+
+const parseCreatedAt = (value) => {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (value instanceof Date) {
+    const timestamp = value.getTime();
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const compareBookIds = (left, right) =>
+  titleCollator.compare(String(left?.book_id ?? ""), String(right?.book_id ?? ""));
+
+const compareTitles = (left, right) =>
+  titleCollator.compare(String(left?.book_title ?? ""), String(right?.book_title ?? ""));
+
+const compareCreatedAt = (left, right) => {
+  const leftCreatedAt = parseCreatedAt(left?.created_at);
+  const rightCreatedAt = parseCreatedAt(right?.created_at);
+
+  if (leftCreatedAt == null && rightCreatedAt == null) {
+    return compareBookIds(left, right);
+  }
+
+  if (leftCreatedAt == null) {
+    return 1;
+  }
+
+  if (rightCreatedAt == null) {
+    return -1;
+  }
+
+  if (leftCreatedAt !== rightCreatedAt) {
+    return leftCreatedAt - rightCreatedAt;
+  }
+
+  return compareBookIds(left, right);
+};
+
+const reverseComparison = (comparison) => (comparison === 0 ? 0 : -comparison);
+
+export const sortBooks = (books = [], sort = DEFAULT_SORT) => {
+  const resolvedSort = normalizeSort(sort);
+
+  return [...books].sort((left, right) => {
+    let comparison;
+
+    if (resolvedSort.field === CREATED_SORT_FIELD) {
+      comparison = compareCreatedAt(left, right);
+    } else {
+      comparison = compareTitles(left, right);
+      if (comparison === 0) {
+        comparison = compareBookIds(left, right);
+      }
+    }
+
+    return resolvedSort.direction === "desc" ? reverseComparison(comparison) : comparison;
+  });
+};
+
+export const cycleSort = (currentSort, field) => {
+  const resolvedSort = normalizeSort(currentSort);
+
+  if (field === TITLE_SORT_FIELD) {
+    if (resolvedSort.field === TITLE_SORT_FIELD) {
+      return resolvedSort.direction === "asc"
+        ? { field: TITLE_SORT_FIELD, direction: "desc" }
+        : DEFAULT_SORT;
+    }
+
+    return DEFAULT_SORT;
+  }
+
+  if (field === CREATED_SORT_FIELD) {
+    if (resolvedSort.field === CREATED_SORT_FIELD) {
+      return resolvedSort.direction === "asc"
+        ? { field: CREATED_SORT_FIELD, direction: "desc" }
+        : DEFAULT_SORT;
+    }
+
+    return { field: CREATED_SORT_FIELD, direction: "asc" };
+  }
+
+  return DEFAULT_SORT;
+};
+
+export const getSortIcon = (sort, field) => {
+  const resolvedSort = normalizeSort(sort);
+  if (resolvedSort.field !== field) {
+    return "swap_vert";
+  }
+
+  return resolvedSort.direction === "desc" ? "arrow_downward" : "arrow_upward";
+};
+
+export const isSortActive = (sort, field) => normalizeSort(sort).field === field;
+
+export const SORT_FIELDS = {
+  TITLE: TITLE_SORT_FIELD,
+  CREATED: CREATED_SORT_FIELD,
+};

--- a/frontend/src/utils/bookSorting.test.js
+++ b/frontend/src/utils/bookSorting.test.js
@@ -1,0 +1,67 @@
+import { DEFAULT_SORT, SORT_FIELDS, cycleSort, sortBooks } from "./bookSorting";
+
+describe("bookSorting", () => {
+  test("sorts titles case-insensitively, punctuation-insensitively, and numerically", () => {
+    const books = [
+      { book_id: "book-c", book_title: "Book 10" },
+      { book_id: "book-a", book_title: "Alpha!" },
+      { book_id: "book-b", book_title: "Book 2" },
+      { book_id: "book-d", book_title: "alpha" },
+    ];
+
+    expect(sortBooks(books, DEFAULT_SORT).map((book) => book.book_id)).toEqual([
+      "book-a",
+      "book-d",
+      "book-b",
+      "book-c",
+    ]);
+  });
+
+  test("sorts created_at values oldest first and newest first", () => {
+    const books = [
+      { book_id: "book-2", book_title: "Beta", created_at: "2026-04-09T10:00:00Z" },
+      { book_id: "book-1", book_title: "Alpha", created_at: "2026-04-08T10:00:00Z" },
+      { book_id: "book-3", book_title: "Gamma", created_at: "2026-04-10T10:00:00Z" },
+    ];
+
+    expect(
+      sortBooks(books, { field: SORT_FIELDS.CREATED, direction: "asc" }).map((book) => book.book_id),
+    ).toEqual(["book-1", "book-2", "book-3"]);
+
+    expect(
+      sortBooks(books, { field: SORT_FIELDS.CREATED, direction: "desc" }).map((book) => book.book_id),
+    ).toEqual(["book-3", "book-2", "book-1"]);
+  });
+
+  test("sorts missing or invalid created_at values last", () => {
+    const books = [
+      { book_id: "book-3", book_title: "Gamma", created_at: null },
+      { book_id: "book-1", book_title: "Alpha", created_at: "2026-04-08T10:00:00Z" },
+      { book_id: "book-2", book_title: "Beta", created_at: "not-a-date" },
+    ];
+
+    expect(
+      sortBooks(books, { field: SORT_FIELDS.CREATED, direction: "asc" }).map((book) => book.book_id),
+    ).toEqual(["book-1", "book-2", "book-3"]);
+  });
+
+  test("uses book_id as the tie breaker", () => {
+    const books = [
+      { book_id: "book-b", book_title: "Same Title" },
+      { book_id: "book-a", book_title: "Same Title" },
+    ];
+
+    expect(sortBooks(books, DEFAULT_SORT).map((book) => book.book_id)).toEqual(["book-a", "book-b"]);
+  });
+
+  test("cycles sort state according to the product rules", () => {
+    expect(cycleSort(DEFAULT_SORT, SORT_FIELDS.TITLE)).toEqual({ field: SORT_FIELDS.TITLE, direction: "desc" });
+    expect(cycleSort({ field: SORT_FIELDS.TITLE, direction: "desc" }, SORT_FIELDS.TITLE)).toEqual(DEFAULT_SORT);
+    expect(cycleSort(DEFAULT_SORT, SORT_FIELDS.CREATED)).toEqual({ field: SORT_FIELDS.CREATED, direction: "asc" });
+    expect(cycleSort({ field: SORT_FIELDS.CREATED, direction: "asc" }, SORT_FIELDS.CREATED)).toEqual({
+      field: SORT_FIELDS.CREATED,
+      direction: "desc",
+    });
+    expect(cycleSort({ field: SORT_FIELDS.CREATED, direction: "desc" }, SORT_FIELDS.CREATED)).toEqual(DEFAULT_SORT);
+  });
+});


### PR DESCRIPTION
Adds phase 1 bookshelf sorting across the Bookshelf, Favorites, and Archive tabs. Users can now sort each tab independently by Title or Created using a two-segment control above the grid, with per-tab in-session state, default Title A-Z, and cycling between ascending, descending, and the default title sort.

To support Created sorting, the backend now includes created_at in book API responses, sourced from GCS blob.time_created or local file timestamps. The frontend was refactored so base library data is no longer forcibly title-sorted in app state; instead, each tab derives its own sorted view client-side.